### PR TITLE
fix display css with locale warning

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -287,7 +287,7 @@
 								{:else}
 									{#if drawerLabel}
 										<div
-											style="font-size: 10pt; left: 0; padding: 10px; position: absolute; right: 0; text-align: center;"
+											style="background: white; font-size: 10pt; left: 0; padding: 10px; position: absolute; right: 0; text-align: center;"
 										>
 											{drawerLabel}
 										</div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

[Example: Fixes #2627](https://github.com/hotosm/field-tm/issues/2627)

## Describe this PR

Add white background to locale warning popup so text doesn't run underneath

## Screenshots

<img width="478" alt="Screenshot 2025-06-30 at 10 08 52 PM" src="https://github.com/user-attachments/assets/de3fb2f4-1a26-4353-b775-e4216f328717" />


## Alternative Approaches Considered

None

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
