### PR TITLE
Fix map draw new feature enabled could select onto existing building

### DIFF
--- a/src/mapper/src/lib/components/map/main.svelte
+++ b/src/mapper/src/lib/components/map/main.svelte
@@ -182,6 +182,9 @@
 
 	// using this function since outside click of entity layer couldn't be tracked via FillLayer
 	function handleMapClick(e: maplibregl.MapMouseEvent) {
+		// if new feature draw mode is active then return
+		if (draw) return;
+
 		let entityLayerName: string = primaryGeomLayerMapping[primaryGeomType];
 		let newEntityLayerName: string = newGeomLayerMapping[drawGeomType];
 
@@ -546,7 +549,9 @@
 		<FlatGeobuf
 			id="entities"
 			url={entitiesStore.fgbOpfsUrl || entitiesUrl}
-			extent={primaryGeomType === MapGeomTypes.POLYLINE ? polygon(projectOutlineCoords).geometry : taskStore.selectedTaskGeom}
+			extent={primaryGeomType === MapGeomTypes.POLYLINE
+				? polygon(projectOutlineCoords).geometry
+				: taskStore.selectedTaskGeom}
 			extractGeomCols={true}
 			promoteId="id"
 			processGeojson={(geojsonData) => entitiesStore.addStatusToGeojsonProperty(geojsonData)}


### PR DESCRIPTION
# What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2539

## Describe this PR
- Don't select an existing entity if the new entity's draw mode is enabled

## Screenshots
https://github.com/user-attachments/assets/ae0d1470-0633-49c4-af27-7599d58e7c7b