### PR TITLE
fix(projects): fix total contributions mismatch in infographics

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -42,7 +42,7 @@ from app.auth.providers.osm import get_osm_token, send_osm_message
 from app.central import central_crud, central_schemas
 from app.config import settings
 from app.db.enums import BackgroundTaskStatus, HTTPStatus, XLSFormType
-from app.db.models import DbBackgroundTask, DbBasemap, DbOrganisation, DbProject, DbUser
+from app.db.models import DbBackgroundTask, DbBasemap, DbProject, DbUser
 from app.db.postgis_utils import (
     check_crs,
     featcol_keep_single_geom_type,
@@ -51,7 +51,7 @@ from app.db.postgis_utils import (
     parse_geojson_file_to_featcol,
     split_geojson_by_task_areas,
 )
-from app.organisations.organisation_deps import get_default_odk_creds, get_org_odk_creds
+from app.organisations.organisation_deps import get_default_odk_creds
 from app.projects import project_deps, project_schemas
 from app.s3 import add_file_to_bucket, add_obj_to_bucket
 from app.submissions.submission_crud import get_submission_by_project
@@ -958,20 +958,7 @@ async def get_project_users_plus_contributions(db: Connection, project_id: int):
             for the specified project.
     """
     try:
-        project = await DbProject.one(db, project_id, minimal=True)
-
-        # Ensure odk_credentials is set
-        if not (
-            project.odk_central_url
-            and project.odk_central_user
-            and project.odk_central_password
-        ):
-            org = await DbOrganisation.one(db, project.organisation_id)
-            odk_creds = await get_org_odk_creds(org)
-            project.odk_central_url = odk_creds.odk_central_url
-            project.odk_central_user = odk_creds.odk_central_user
-            project.odk_central_password = odk_creds.odk_central_password
-            project.odk_credentials = odk_creds
+        project = await DbProject.one(db, project_id, minimal=False)
 
         # Fetch all submissions for the project
         data = await get_submission_by_project(project, {})

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -76,7 +76,7 @@ from app.db.postgis_utils import (
 )
 from app.organisations import organisation_deps
 from app.projects import project_crud, project_deps, project_schemas
-from app.projects.project_schemas import ProjectContributor
+from app.projects.project_schemas import ProjectUserContributions
 from app.s3 import delete_all_objs_under_prefix
 from app.users.user_deps import get_user
 from app.users.user_schemas import UserRolesOut
@@ -412,7 +412,7 @@ async def get_task_status(
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e)) from e
 
 
-@router.get("/contributors/{project_id}", response_model=list[ProjectContributor])
+@router.get("/contributors/{project_id}", response_model=list[ProjectUserContributions])
 async def get_contributors(
     db: Annotated[Connection, Depends(db_conn)],
     project_user: Annotated[ProjectUserDict, Depends(Mapper())],

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -76,6 +76,7 @@ from app.db.postgis_utils import (
 )
 from app.organisations import organisation_deps
 from app.projects import project_crud, project_deps, project_schemas
+from app.projects.project_schemas import ProjectContributor
 from app.s3 import delete_all_objs_under_prefix
 from app.users.user_deps import get_user
 from app.users.user_schemas import UserRolesOut
@@ -411,15 +412,12 @@ async def get_task_status(
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e)) from e
 
 
-@router.get("/contributors/{project_id}")
+@router.get("/contributors/{project_id}", response_model=list[ProjectContributor])
 async def get_contributors(
     db: Annotated[Connection, Depends(db_conn)],
     project_user: Annotated[ProjectUserDict, Depends(Mapper())],
 ):
-    """Get contributors of a project.
-
-    TODO use a pydantic model for return type
-    """
+    """Get contributors of a project."""
     project = project_user.get("project")
     return await project_crud.get_project_users_plus_contributions(db, project.id)
 

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -383,3 +383,10 @@ class ProjectTeamIn(ProjectTeamOne):
 
     # Exclude, as the uuid is generated in the database
     team_id: Annotated[Optional[UUID], Field(exclude=True)] = None
+
+
+class ProjectContributor(BaseModel):
+    """A single project contributor and their submission count."""
+
+    user: str
+    submissions: int

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -267,10 +267,10 @@ class PaginatedProjectSummaries(BaseModel):
 
 
 class ProjectUserContributions(BaseModel):
-    """Users for a project, plus contribution count."""
+    """A single project contributor and their submission count."""
 
     user: str
-    contributions: int
+    submissions: int
 
 
 class BasemapGenerate(BaseModel):
@@ -383,10 +383,3 @@ class ProjectTeamIn(ProjectTeamOne):
 
     # Exclude, as the uuid is generated in the database
     team_id: Annotated[Optional[UUID], Field(exclude=True)] = None
-
-
-class ProjectContributor(BaseModel):
-    """A single project contributor and their submission count."""
-
-    user: str
-    submissions: int

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -613,7 +613,8 @@ async def test_update_and_download_project_form(client, project):
         assert response.content == b"updated xlsform data"
 
 
-async def test_get_contributors(client, project, task_events, admin_user):
+# NOTE we need odk_project and task_events fixture to populate data
+async def test_get_contributors(client, project, odk_project, task_events, admin_user):
     """Test fetching contributors of a project."""
     response = await client.get(f"projects/contributors/{project.id}")
     assert response.status_code == 200

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -622,12 +622,12 @@ async def test_get_contributors(client, project, task_events, admin_user):
     assert isinstance(data, list)
     assert len(data) > 0
     assert all(
-        "user" in contributor and "contributions" in contributor for contributor in data
+        "user" in contributor and "submissions" in contributor for contributor in data
     )
 
     contributor = data[0]
     assert contributor["user"] == admin_user.username
-    assert contributor["contributions"] == 2
+    assert contributor["submissions"] == 2
 
 
 async def test_add_new_project_manager(client, project, new_mapper_user):

--- a/src/frontend/src/components/ProjectSubmissions/SubmissionsInfographics.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/SubmissionsInfographics.tsx
@@ -200,15 +200,15 @@ const SubmissionsInfographics = ({ toggleView, entities }) => {
                   )}
                 />
                 <TableHeader
-                  dataField="Contributions"
+                  dataField="Submissions"
                   headerClassName="codeHeader"
                   rowClassName="codeRow"
                   dataFormat={(row) => (
                     <div
                       className="fmtm-w-[7rem] fmtm-max-w-[7rem] fmtm-overflow-hidden fmtm-truncate"
-                      title={row?.contributions}
+                      title={row?.submissions}
                     >
-                      <span className="fmtm-text-[15px]">{row?.contributions}</span>
+                      <span className="fmtm-text-[15px]">{row?.submissions}</span>
                     </div>
                   )}
                 />

--- a/src/frontend/src/components/ProjectSubmissions/SubmissionsInfographics.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/SubmissionsInfographics.tsx
@@ -187,7 +187,7 @@ const SubmissionsInfographics = ({ toggleView, entities }) => {
                 />
 
                 <TableHeader
-                  dataField="OSMID"
+                  dataField="User"
                   headerClassName="codeHeader"
                   rowClassName="codeRow"
                   dataFormat={(row) => (


### PR DESCRIPTION
- Updated `get_project_users_plus_contributions` to fetch and count user submissions for a project.
- Introduced `ProjectContributor` schema for structured response.
- Modified API route to return contributors with submission counts.
- Updated frontend to reflect changes in submission terminology from "Contributions" to "Submissions".

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Total contributions on infographics doesn't match with number of submissions by respective users #2304

## Describe this PR

Modified the total contributors table to show number of submissions per user including new features submissions.
Used the ODK Central API to fetch all form submissions for the project and counted them per user.
Modified the Frontend to display submissions in the table

## Screenshots

<img width="419" alt="image" src="https://github.com/user-attachments/assets/087bf164-ef46-496e-926a-308bd8570a4d" />


## Review Guide

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
