### PR TITLE
Remove custom web-forms caching by key, defer to workbox pwa

### DIFF
--- a/src/mapper/src/lib/api/fetch.ts
+++ b/src/mapper/src/lib/api/fetch.ts
@@ -4,42 +4,6 @@ import { DbApiSubmission } from '$lib/db/api-submissions.ts';
 
 const API_URL = import.meta.env.VITE_API_URL;
 
-const DEFAULT_CACHE_NAME = 'c488ea01-8c52-4a18-a93e-934bc77f1eb8';
-
-async function fetchCachedBlobUrl(url: string, cacheName: string, clean: boolean): Promise<string> {
-	// delete old cache entries
-	if (clean) await clearCacheStorage(url, cacheName);
-
-	const cacheStorage = await caches.open(cacheName || DEFAULT_CACHE_NAME);
-	const response = await cacheStorage.match(url);
-	if (response) {
-		const blob = await response.blob();
-		return URL.createObjectURL(blob);
-	} else {
-		const response = await fetch(url);
-		// clone the response stream as it can only be consumed again
-		cacheStorage.put(url, response.clone());
-		const blob = await response.blob();
-		return URL.createObjectURL(blob);
-	}
-}
-
-/**
- *
- * @param url - url to look for
- * @param keep - skip checking this cache
- */
-async function clearCacheStorage(url: string, skip: string) {
-	const keys = await caches.keys();
-	for (let i = 0; i < keys.length; i++) {
-		const key = keys[i];
-		if (key !== skip) {
-			const cacheStorage = await caches.open(key);
-			await cacheStorage.delete(url);
-		}
-	}
-}
-
 /**
  * @name fetchBlobUrl
  * @param url - url to a web resource like a script or xml file
@@ -123,4 +87,4 @@ async function trySendingSubmission(db: PGlite, row: DbApiSubmissionType): Promi
 	}
 }
 
-export { fetchCachedBlobUrl, fetchBlobUrl, fetchFormMediBlobUrls, trySendingSubmission };
+export { fetchBlobUrl, fetchFormMediBlobUrls, trySendingSubmission };

--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -7,7 +7,7 @@
 	import { getCommonStore } from '$store/common.svelte.ts';
 	import { getLoginStore } from '$store/login.svelte.ts';
 	import { getEntitiesStatusStore } from '$store/entities.svelte.ts';
-	import { fetchCachedBlobUrl, fetchFormMediBlobUrls } from '$lib/api/fetch';
+	import { fetchFormMediBlobUrls } from '$lib/api/fetch';
 	import { getDeviceId } from '$lib/utils/random';
 	import { m } from '$translations/messages.js';
 
@@ -48,14 +48,8 @@
 	let uploading = $state(false);
 	let uploadingMessage = $state('');
 
-	const odkWebFormPromise = fetchCachedBlobUrl(
-		'https://hotosm.github.io/web-forms/odk-web-form.js',
-		commonStore.config.cacheName,
-		true, // clean old cache entries
-	);
-
-	const webFormPagePromise = fetchCachedBlobUrl('/web-forms.html', commonStore.config.cacheName, true);
-
+	const odkWebFormUrl = 'https://hotosm.github.io/web-forms/odk-web-form.js';
+	const webFormPageUrl = '/web-forms.html';
 	const formMediaPromise = fetchFormMediBlobUrls(projectId!);
 
 	function insertExtraMetadataIntoSubmissionXml(submissionXml: string): string {
@@ -270,51 +264,47 @@
 	placement="start"
 	class="forms-wrapper-drawer"
 >
-	{#await odkWebFormPromise then odkWebFormUrl}
-		{#await webFormPagePromise then webFormPageUrl}
-			{#if entityId}
-				{#key projectId}
-					{#await formMediaPromise then formMedia}
-						{#key entityId}
-							{#key commonStore.locale}
-								{#if uploading}
-									<div id="web-forms-uploader">
-										<div id="uploading-inner">
-											<div id="spinner"></div>
-											{uploadingMessage}
-										</div>
-									</div>
-								{:else}
-									{#if drawerLabel}
-										<div
-											style="background: white; font-size: 10pt; left: 0; padding: 10px; position: absolute; right: 0; text-align: center;"
-										>
-											{drawerLabel}
-										</div>
-									{/if}
-									<iframe
-										class="iframe"
-										style="border: none; height: 100%; height: -webkit-fill-available;"
-										use:handleIframe
-										title="odk-web-forms-wrapper"
-										id={WEB_FORMS_IFRAME_ID}
-										name={WEB_FORMS_IFRAME_ID}
-										src={`${webFormPageUrl}`}
-										data-project-id={projectId}
-										data-entity-id={entityId}
-										data-form-xml={formXml}
-										data-odk-web-form-url={odkWebFormUrl}
-										data-form-media={encodeURIComponent(JSON.stringify(formMedia))}
-										data-css-file={commonStore.config?.cssFileWebformsOverride || ''}
-									></iframe>
-								{/if}
-							{/key}
-						{/key}
-					{/await}
+	{#if entityId}
+		{#key projectId}
+			{#await formMediaPromise then formMedia}
+				{#key entityId}
+					{#key commonStore.locale}
+						{#if uploading}
+							<div id="web-forms-uploader">
+								<div id="uploading-inner">
+									<div id="spinner"></div>
+									{uploadingMessage}
+								</div>
+							</div>
+						{:else}
+							{#if drawerLabel}
+								<div
+									style="background: white; font-size: 10pt; left: 0; padding: 10px; position: absolute; right: 0; text-align: center;"
+								>
+									{drawerLabel}
+								</div>
+							{/if}
+							<iframe
+								class="iframe"
+								style="border: none; height: 100%; height: -webkit-fill-available;"
+								use:handleIframe
+								title="odk-web-forms-wrapper"
+								id={WEB_FORMS_IFRAME_ID}
+								name={WEB_FORMS_IFRAME_ID}
+								src={`${webFormPageUrl}`}
+								data-project-id={projectId}
+								data-entity-id={entityId}
+								data-form-xml={formXml}
+								data-odk-web-form-url={odkWebFormUrl}
+								data-form-media={encodeURIComponent(JSON.stringify(formMedia))}
+								data-css-file={commonStore.config?.cssFileWebformsOverride || ''}
+							></iframe>
+						{/if}
+					{/key}
 				{/key}
-			{/if}
-		{/await}
-	{/await}
+			{/await}
+		{/key}
+	{/if}
 </hot-drawer>
 
 <style>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Looking into this during https://github.com/hotosm/field-tm/issues/2674

## Describe this PR

- We implemented a custom caching mechanism for webforms, to avoid loading every time a feature is clicked.
- Since then, we added workbox runtime caching.
- Ideally the webforms can be cached as part of the PWA workbox config.
- If you think it's feasible, could you please continue this @DanielJDufour 🙏?
- If not, we can close and keep caching manually - but we need a way to avoid the cache conflicts that keep occurring (perhaps we need a rule to omit this path in workbox too).

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
