### PR TITLE
Pass access token to generate osm extracts

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -33,7 +33,12 @@ from asgiref.sync import async_to_sync
 from fastapi import HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from loguru import logger as log
-from osm_data_client import RawDataOutputOptions, RawDataResult, RawDataClientConfig, RawDataClient
+from osm_data_client import (
+    RawDataClient,
+    RawDataClientConfig,
+    RawDataOutputOptions,
+    RawDataResult,
+)
 from osm_login_python.core import Auth
 from psycopg import Connection, sql
 from psycopg.rows import class_row
@@ -155,29 +160,26 @@ async def generate_data_extract(
             status_code=HTTPStatus.BAD_REQUEST,
             detail="To generate a new data extract a extract_config must be specified.",
         )
-    config= RawDataClientConfig(
+    config = RawDataClientConfig(
         access_token=settings.RAW_DATA_API_AUTH_TOKEN.get_secret_value()
         if settings.RAW_DATA_API_AUTH_TOKEN
         else None
     )
-    extra_params={
-        "fileName":(
+    extra_params = {
+        "fileName": (
             f"fmtm/{settings.FMTM_DOMAIN}/data_extract_{project_id}"
             if settings.RAW_DATA_API_AUTH_TOKEN
             else f"fmtm_extract_{project_id}"
         ),
-        
-        "outputType":"geojson",
-        "geometryType":[geom_type],
-        "bindZip":False,
-        "centroid":centroid,
-        "use_st_within":(False if geom_type == "line" else True),
-        "filters":config_json,
+        "outputType": "geojson",
+        "geometryType": [geom_type],
+        "bindZip": False,
+        "centroid": centroid,
+        "use_st_within": (False if geom_type == "line" else True),
+        "filters": config_json,
     }
     result = await RawDataClient(config).get_osm_data(
-        aoi,
-        output_options=RawDataOutputOptions(download_file=False),
-        **extra_params
+        aoi, output_options=RawDataOutputOptions(download_file=False), **extra_params
     )
 
     return result


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Filename with folder structure is not allowed without providing access token

## Describe this PR

This PR refactors `generate_data_extracts` adding access token (`RAW_DATA_API_AUTH_TOKEN`).


## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
