### PR TITLE
Update visibility filter to projects based on access

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1844,7 +1844,8 @@ class DbProject(BaseModel):
         return """
         (
             (p.visibility = 'PUBLIC' AND p.status != 'DRAFT')
-            OR EXISTS (
+            OR
+            EXISTS (
                 SELECT 1 FROM user_roles ur
                 WHERE ur.project_id = p.id
                 AND ur.user_sub = %(current_user_sub)s

--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1838,21 +1838,19 @@ class DbProject(BaseModel):
 
         # Regular users see:
         # 1. Public non-draft projects
-        # 2. Private projects they have access to (if they're a project manager,
-        # they can see drafts)
+        # 2. Projects they have access to:
+        #    - If Any user is assigned as a project manager in any project,
+        # can see public projects and assigned project even it is draft
         return """
         (
             (p.visibility = 'PUBLIC' AND p.status != 'DRAFT')
-            OR (
-                p.visibility = 'PRIVATE'
-                AND EXISTS (
-                    SELECT 1 FROM user_roles ur
-                    WHERE ur.project_id = p.id
-                    AND ur.user_sub = %(current_user_sub)s
-                    AND (
-                        ur.role = 'PROJECT_MANAGER'
-                        OR p.status != 'DRAFT'
-                    )
+            OR EXISTS (
+                SELECT 1 FROM user_roles ur
+                WHERE ur.project_id = p.id
+                AND ur.user_sub = %(current_user_sub)s
+                AND (
+                    ur.role = 'PROJECT_MANAGER'
+                    OR p.status != 'DRAFT'
                 )
             )
         )
@@ -2392,6 +2390,7 @@ class DbBasemap(BaseModel):
     created_at: Optional[AwareDatetime] = None
 
     # Calculated
+
     bbox: Optional[list[float]] = None
 
     @classmethod

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -110,7 +110,7 @@ async def read_projects(
     limit: int = 100,
 ):
     """Return all projects."""
-    projects = await DbProject.all(db, skip, limit, user_sub)
+    projects = await DbProject.all(db, skip, limit, current_user, user_sub)
     return projects
 
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2695 

## Describe this PR

This PR implements visibility filtering for draft projects in Field-TM with the following rules:

### Public Users (Not Logged In)
- Can only see public AND non-draft projects

### Superadmins
- Full access to all projects including drafts
- No visibility restrictions

### Organization Managers
- Can see all projects in their organizations including drafts
- Can see all public projects
- Have full visibility within their organization scope

### Project Managers
- Can see draft projects for projects they manage
- Can see public non-draft projects
- Regular visibility rules apply for other projects

### Regular Users
- Can see public non-draft projects
- Cannot see draft projects unless they are a project manager


## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
