### PR TITLE
Fix project visibility to exclude draft projects for cross organiisation admins

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1831,7 +1831,7 @@ class DbProject(BaseModel):
             # Org managers see all projects in their orgs including drafts
             return """
             (
-                p.visibility = 'PUBLIC'
+                (p.visibility = 'PUBLIC' AND p.status != 'DRAFT')
                 OR p.organisation_id = ANY(%(managed_org_ids)s)
             )
         """


### PR DESCRIPTION
…ss organisation manager

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2726 

## Describe this PR

Updated the _build_visibility_filter method to properly enforce organization-level privacy:

### Non-logged in users: Only see public non-draft projects
- Superadmins: Can see all projects (unchanged)

### Organization managers: Can see:
- All public non-draft projects
- All projects in their organizations (including private/draft)

### Regular users: Can see:
- Public non-draft projects
- Private/draft projects ONLY if explicitly assigned as PROJECT_MANAGER
- Public non-draft projects they're assigned to

## Screenshots

<img width="1439" height="789" alt="image" src="https://github.com/user-attachments/assets/f6553a1b-e345-45a9-920b-16acb01c8cf1" />
<img width="1410" height="775" alt="image" src="https://github.com/user-attachments/assets/f76f8a29-0d0a-41ee-b4aa-e5d38c13e152" />

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
