### PR TITLE
Backend part to allow listing of required media from uploaded XLSForm

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -1058,3 +1058,22 @@ async def get_form_media(
         }
 
     return form_attachment_urls
+
+
+async def list_form_media(
+    xform_id: str,
+    project_odk_id: int,
+    odk_credentials: central_schemas.ODKCentralDecrypted,
+) -> list[dict]:
+    """Return a list of form media required for upload.
+
+    Format:
+        [
+            {'name': '1731673738156.jpg', 'exists': False},
+        ]
+    """
+    async with central_deps.get_async_odk_form(odk_credentials) as async_odk_form:
+        return await async_odk_form.listFormAttachments(
+            project_odk_id,
+            xform_id,
+        )

--- a/src/backend/app/central/central_routes.py
+++ b/src/backend/app/central/central_routes.py
@@ -351,6 +351,36 @@ async def upload_form_media(
         ) from e
 
 
+@router.post("/list-form-media", response_model=list[dict])
+async def list_form_media(
+    project_user: Annotated[ProjectUserDict, Depends(Mapper())],
+):
+    """A list of required media to upload for a form."""
+    project = project_user.get("project")
+    project_id = project.id
+    project_odk_id = project.odkid
+    project_xform_id = project.odk_form_id
+    project_odk_creds = project.odk_credentials
+
+    try:
+        form_media = await central_crud.list_form_media(
+            project_xform_id,
+            project_odk_id,
+            project_odk_creds,
+        )
+
+        return form_media
+    except Exception as e:
+        msg = (
+            f"Failed to list all form media for Field-TM project ({project_id}) "
+            f"ODK project ({project_odk_id}) form ID ({project_xform_id})"
+        )
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=msg,
+        ) from e
+
+
 @router.post("/get-form-media", response_model=dict[str, str])
 async def get_form_media(
     project_user: Annotated[ProjectUserDict, Depends(Mapper())],

--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
@@ -248,7 +248,7 @@ class OdkForm(OdkCentral):
             async with self.session.get(url, ssl=self.verify) as response:
                 return await response.json()
         except aiohttp.ClientError as e:
-            msg = f"Error fetching submissions: {e}"
+            msg = f"Error fetching form attachments: {e}"
             log.error(msg)
             raise aiohttp.ClientError(msg) from e
 

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -379,21 +379,29 @@ async def odk_project(db, client, project, tasks):
     with open(xlsform_file, "rb") as xlsform_data:
         xlsform_obj = BytesIO(xlsform_data.read())
 
-    xform_file = {
-        "xlsform": (
-            "buildings.xls",
-            xlsform_obj,
+    try:
+        response = await client.post(
+            f"/central/upload-xlsform?project_id={project.id}",
+            files={
+                "xlsform": (
+                    "buildings.xls",
+                    xlsform_obj,
+                )
+            },
         )
-    }
+        log.debug(f"Uploaded XLSForm for project: {project.id}")
+    except Exception as e:
+        log.exception(e)
+        pytest.fail(f"Failed to upload XLSForm for project: {str(e)}")
+
     try:
         response = await client.post(
             f"/projects/{project.id}/generate-project-data",
-            files=xform_file,
         )
         log.debug(f"Generated project files for project: {project.id}")
     except Exception as e:
         log.exception(e)
-        pytest.fail(f"Test failed with exception: {str(e)}")
+        pytest.fail(f"Failed to generate project files: {str(e)}")
 
     yield project
 

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -367,7 +367,7 @@ async def test_generate_project_files(db, client, project):
         xlsform_obj = BytesIO(xlsform_data.read())
 
     response = await client.post(
-        f"/central/upload-xlsform?project_id{project_id}",
+        f"/central/upload-xlsform?project_id={project_id}",
         files={
             "xlsform": (
                 "buildings.xls",

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -366,21 +366,25 @@ async def test_generate_project_files(db, client, project):
     with open(xlsform_file, "rb") as xlsform_data:
         xlsform_obj = BytesIO(xlsform_data.read())
 
-    xform_file = {
-        "xlsform": (
-            "buildings.xls",
-            xlsform_obj,
-        )
-    }
+    response = await client.post(
+        f"/central/upload-xlsform?project_id{project_id}",
+        files={
+            "xlsform": (
+                "buildings.xls",
+                xlsform_obj,
+            )
+        },
+    )
+    assert response.status_code == 200
+
     response = await client.post(
         f"/projects/{project_id}/generate-project-data",
-        files=xform_file,
     )
     assert response.status_code == 200
 
     # Now check required values were added to project
     new_project = await DbProject.one(db, project_id)
-    assert len(new_project.tasks) == 1
+    assert new_project.tasks and len(new_project.tasks) == 1
     assert new_project.tasks[0].task_state == MappingState.UNLOCKED_TO_MAP
     assert isinstance(new_project.odk_token, str)
 

--- a/src/frontend/src/components/CreateProject/constants/defaultValues.ts
+++ b/src/frontend/src/components/CreateProject/constants/defaultValues.ts
@@ -32,6 +32,7 @@ export const defaultValues: z.infer<typeof createProjectValidationSchema> = {
   osm_category: '',
   xlsFormFile: null,
   isXlsFormFileValid: false,
+  needVerificationFields: true,
 
   // 04 Map Data
   primary_geom_type: null,

--- a/src/frontend/src/components/CreateProject/validation.ts
+++ b/src/frontend/src/components/CreateProject/validation.ts
@@ -126,6 +126,7 @@ export const uploadSurveyValidationSchema = z
     osm_category: z.string().min(1, 'Form Category is must be selected'),
     xlsFormFile: z.any().optional(),
     isXlsFormFileValid: z.boolean(),
+    needVerificationFields: z.boolean(),
   })
   .check((ctx) => {
     const values = ctx.value;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to https://github.com/hotosm/field-tm/issues/2693
Backend part of https://github.com/hotosm/field-tm/issues/2342

## Describe this PR

- Moved the XLSForm upload from the end of project creation to the form upload page.
- The project creation `generate-project-files` doesn't do as much work now.
- The user gets immediate feedback on their form & we can now display the 'required media' specified in the form (taken from ODK Central validation endpoint).
- I also added an endpoint `/central/list-form-media` to allow us to get a list of required files to upload.
- We can implement a frontend dropzone next to allow users to POST to `/central/upload-form-media`.

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
