### PR TITLE
Fix mapper frontend issues

### DIFF
--- a/src/mapper/src/routes/project/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/project/[projectId]/+page.svelte
@@ -151,7 +151,7 @@
 
 		// Set vars that require upstream project details set (and are not reactive)
 		if (project) {
-			commonStore.setUseOdkCollectOverride(project.use_odk_collect);
+			commonStore.setEnableWebForms(!project.use_odk_collect);
 			const { odk_form_xml } = project;
 			const formXmlBlob = new Blob([odk_form_xml], { type: 'application/xml' });
 			formXmlUrl = URL.createObjectURL(formXmlBlob);
@@ -397,7 +397,7 @@
 			newFeatureDrawInstance.setMode('select');
 		}}
 		syncButtonTrigger={async () => {
-			await entitiesStore.syncEntityStatusManually(projectId)
+			await entitiesStore.syncEntityStatusManually(projectId);
 		}}
 	></MapComponent>
 

--- a/src/mapper/src/store/common.svelte.ts
+++ b/src/mapper/src/store/common.svelte.ts
@@ -32,8 +32,7 @@ let projectBasemaps: Basemap[] = $state([]);
 let projectPmtilesUrl: string | null = $state(null);
 let selectedTab: string = $state('map');
 let config: ConfigJson | null = $state(null);
-let useOdkCollectOverride: boolean = $state(false);
-let enableWebforms = $derived<boolean>(!useOdkCollectOverride && config?.enableWebforms ? true : false);
+let enableWebforms = $state(false);
 let offlineDataIsSyncing: boolean = $state(false);
 let offlineSyncPercentComplete: number | null = $state(null);
 
@@ -83,7 +82,7 @@ function getCommonStore() {
 			return config;
 		},
 		setConfig: (fetchedConfig: ConfigJson) => (config = fetchedConfig),
-		setUseOdkCollectOverride: (isEnabled: boolean) => (useOdkCollectOverride = isEnabled),
+		setEnableWebForms: (isEnabled: boolean) => (enableWebforms = isEnabled),
 		get enableWebforms() {
 			return enableWebforms;
 		},

--- a/src/mapper/src/store/tasks.svelte.ts
+++ b/src/mapper/src/store/tasks.svelte.ts
@@ -42,14 +42,7 @@ function getTaskStore() {
 
 		eventsUnsubscribe = taskEventShape?.subscribe((taskEventData: ShapeData[]) => {
 			let taskEventRows: TaskEventType[];
-			if (events.length > 0) {
-				// If we already have data, only append data changes made since last update
-				taskEventRows = taskEventData.rows
-					.filter((item): item is { value: TaskEventType } => 'value' in item && item.value !== null)
-					.map((item) => item.value);
-			} else {
-				taskEventRows = taskEventData.rows;
-			}
+			taskEventRows = taskEventData.rows;
 
 			if (taskEventRows.length) {
 				latestEvent = taskEventRows.at(-1) ?? null;
@@ -67,7 +60,7 @@ function getTaskStore() {
 
 				// Update the state of currently selected task area
 				for (const newEvent of taskEventRows) {
-					if (newEvent.task_id === selectedTaskId) {
+					if (+newEvent.task_id === selectedTaskId) {
 						selectedTaskState = newEvent.state;
 					}
 				}
@@ -114,11 +107,8 @@ function getTaskStore() {
 		selectedTaskId = taskId;
 		selectedTaskIndex = taskIndex;
 
-		if (!taskId) return;
-
 		// Filter the local `events` store for matching task_id
 		const taskRows = events.filter((ev) => ev.task_id === taskId);
-		if (!taskRows.length) return;
 
 		// Pick the latest event for this task
 		selectedTask = taskRows.at(-1) ?? null;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2737

## Describe this PR
- Fix task selection, task popup issue
- Display webforms or ODK app workflow based on `use_odk_collect` flag on project state

## Screenshots
<img width="1069" height="883" alt="image" src="https://github.com/user-attachments/assets/30760fc7-0fc5-4999-8209-e1488763198a" />
<img width="1111" height="875" alt="image" src="https://github.com/user-attachments/assets/4da03093-f60d-4260-a3c4-b9f77d25f1f5" />

## Alternative Approaches Considered
I guess the following logic was also causing issues on task selection if the events length was greater than 0. Also, looking at the code, we don't need to filter and map the rows because all the `taskEventData.rows` items had `value` and it was giving the same result as `taskEventRows = taskEventData.rows`
```
if (events.length > 0) {
	// If we already have data, only append data changes made since last update
	taskEventRows = taskEventData.rows
		.filter((item): item is { value: TaskEventType } => 'value' in item && item.value !== null)
		.map((item) => item.value);
} else {
	taskEventRows = taskEventData.rows;
}
```