### PR TITLE
fixed option image display

### DIFF
--- a/src/mapper/static/web-forms.html
+++ b/src/mapper/static/web-forms.html
@@ -15,6 +15,12 @@
 				margin-right: 10px;
 				box-sizing: border-box;
 			}
+			.columns-pack label.value-option.no-buttons .text-content {
+				display: none;
+			}
+			.columns-pack label.value-option.no-buttons .media-content {
+				display: none;
+			}
 			.columns-pack .p-radiobutton.p-component {
 				display: none;
 			}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

N/A

## Describe this PR

The new version of ODK web forms changed styling, so it would displays a "no image found" image for columns pack options as well as the title of the option.  We want to hide that because our assumption is that people are attaching images as form media.  (I'm not sure how ODK central *wants* you to do it now.  Maybe they added support for image choices?)

## Screenshots

with fix:
<img width="162" height="226" alt="Screenshot 2025-08-05 at 9 52 50 PM" src="https://github.com/user-attachments/assets/f6e6e51b-38cd-4551-9935-3a00be253067" />

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
