### PR TITLE
Add project status in organisation stats.

### DIFF
--- a/src/backend/app/organisations/organisation_schemas.py
+++ b/src/backend/app/organisations/organisation_schemas.py
@@ -18,14 +18,14 @@
 """Pydantic models for Organisations."""
 
 from datetime import date
-from typing import Annotated, List, Optional, Self
+from typing import Annotated, Dict, List, Optional, Self
 
 from fastapi import Form
 from pydantic import BaseModel, Field
 from pydantic.functional_validators import model_validator
 
 from app.central.central_schemas import ODKCentralIn
-from app.db.enums import CommunityType, OrganisationType
+from app.db.enums import CommunityType, OrganisationType, ProjectStatus
 from app.db.models import DbOrganisation, slugify
 
 
@@ -130,6 +130,7 @@ class Overview(BaseModel):
     active_projects: int
     total_submissions: int
     total_contributors: int
+    project_status_counts: Optional[Dict[ProjectStatus, int]] = None
 
 
 class ProjectTaskStatus(BaseModel):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2470 

## Describe this PR

This PR enhances the /organisation/{org_id}/stats endpoint by including project_status_counts in the overview section of the response. This new field provides a breakdown of the number of projects in each status (DRAFT, PUBLISHED, COMPLETED, etc.).

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
