### PR TITLE
Refactor project visibility removing SENSITIVE and INVITE_ONLY.

### DIFF
--- a/src/backend/app/auth/roles.py
+++ b/src/backend/app/auth/roles.py
@@ -418,7 +418,7 @@ async def project_contributors(
         WHERE sub = %(user_sub)s
             AND (
                 CASE
-                WHEN %(visibility)s IN ('SENSITIVE', 'PRIVATE') THEN
+                WHEN %(visibility)s = 'PRIVATE' THEN
                     CASE
                     WHEN role = 'ADMIN' THEN true
                     WHEN EXISTS (

--- a/src/backend/app/db/enums.py
+++ b/src/backend/app/db/enums.py
@@ -200,17 +200,10 @@ class ProjectVisibility(StrEnum, Enum):
     PRIVATE: The project is not visible to any users until they are invited to the
     project and submissions are only accessible to authenticated users who are
     contributors to the project.
-
-    SENSITIVE: All data is publicly available to all users, however submissions are only
-    accessible to authenticated users who are contributors to the project.
-
-    INVITE_ONLY: Only invited users can access the project, but access all data.
     """
 
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"
-    SENSITIVE = "SENSITIVE"
-    INVITE_ONLY = "INVITE_ONLY"
 
 
 class CommunityType(StrEnum, Enum):

--- a/src/backend/app/submissions/submission_crud.py
+++ b/src/backend/app/submissions/submission_crud.py
@@ -320,7 +320,7 @@ async def get_project_submission_geojson(project, filters):
 async def upload_submission_geojson_to_s3(project, submission_geojson):
     """Handles submission GeoJSON generation and upload to S3 for a single project."""
     # FIXME Maybe upload the skipped projects to S3 in private buckets in the future?
-    if project.visibility not in ["PUBLIC", "INVITE_ONLY"] or project.status in [
+    if project.visibility != "PUBLIC" or project.status in [
         ProjectStatus.COMPLETED,
         ProjectStatus.ARCHIVED,
     ]:

--- a/src/migrations/001-remove-sensitive-visibility-enum.sql
+++ b/src/migrations/001-remove-sensitive-visibility-enum.sql
@@ -1,0 +1,41 @@
+-- ## Migration to:
+-- * Remove 'SENSITIVE' and 'INVITE_ONLY' from projectvisibility enum
+
+BEGIN;
+
+-- Step 1: Normalize data
+UPDATE projects
+SET visibility = 'PRIVATE'
+WHERE visibility::text IN ('SENSITIVE', 'INVITE_ONLY');
+
+-- Step 2: Clean up enum if needed
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_type WHERE typname = 'projectvisibility'
+    ) THEN
+        IF EXISTS (
+            SELECT 1 FROM pg_enum
+            WHERE enumtypid = 'projectvisibility'::regtype
+            AND enumlabel IN ('SENSITIVE', 'INVITE_ONLY')
+        ) THEN
+            -- Rename old type
+            ALTER TYPE projectvisibility RENAME TO projectvisibility_old;
+
+            -- Create clean enum type
+            CREATE TYPE projectvisibility AS ENUM ('PUBLIC', 'PRIVATE');
+
+            -- Convert column to new enum
+            ALTER TABLE projects
+            ALTER COLUMN visibility TYPE projectvisibility
+            USING visibility::text::projectvisibility;
+
+            -- Drop old enum
+            DROP TYPE projectvisibility_old;
+        ELSE        
+        END IF;
+    ELSE
+    END IF;
+END$$;
+
+COMMIT;

--- a/src/migrations/init/shared/1-enums.sql
+++ b/src/migrations/init/shared/1-enums.sql
@@ -18,9 +18,7 @@ ALTER TYPE public.projectstatus OWNER TO fmtm;
 
 CREATE TYPE public.projectvisibility AS ENUM (
     'PUBLIC',
-    'PRIVATE',
-    'INVITE_ONLY',
-    'SENSITIVE'
+    'PRIVATE'
 );
 ALTER TYPE public.projectvisibility OWNER TO fmtm;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2659 

## Describe this PR

This PR removes deprecated SENSITIVE and INVITE_ONLY values from the ProjectVisibility enum and ensures the codebase reflects this change.

### **1. Refactored projectvisibility enum**
- Removed deprecated values: SENSITIVE and INVITE_ONLY

### **2. Updated role-based visibility logic in roles.py**
- Now handles only 'PUBLIC' and 'PRIVATE' visibility options

### **3. Modified initial enum definition**
- Removed SENSITIVE and INVITE_ONLY from migrations/init/shared/1-enums.sql to keep new setups clean

### **4. Added custom SQL migration**
- Converts existing SENSITIVE/INVITE_ONLY values to PRIVATE
- Replaces the enum type in the database
- Fully idempotent: safe for repeated execution.



## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
