### PR TITLE
Add 'use_st_within' option for OSM data extract generation

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -136,6 +136,7 @@ async def generate_data_extract(
     geom_type: str,
     config_json=None,
     centroid: bool = False,
+    use_st_within: bool = True,
 ) -> RawDataResult:
     """Request a new data extract in flatgeobuf format.
 
@@ -147,6 +148,7 @@ async def generate_data_extract(
         config_json (Optional[json], optional):
             Configuration for data extraction. Defaults to None.
         centroid (bool): Generate centroid of polygons.
+        use_st_within (bool): Include features within the AOI.
 
     Raises:
         HTTPException:
@@ -176,7 +178,7 @@ async def generate_data_extract(
         "geometryType": [geom_type],
         "bindZip": False,
         "centroid": centroid,
-        "use_st_within": (False if geom_type == "line" else True),
+        "use_st_within": (False if geom_type == "line" else use_st_within),
         "filters": config_json,
     }
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -538,6 +538,7 @@ async def get_data_extract(
     osm_category: Annotated[Optional[XLSFormType], Form()] = XLSFormType.buildings,
     centroid: Annotated[bool, Form()] = False,
     geom_type: Annotated[DbGeomType, Form()] = DbGeomType.POLYGON,
+    use_st_within: Annotated[bool, Form()] = True,
 ):
     """Get a new data extract for a given project AOI.
 
@@ -574,6 +575,7 @@ async def get_data_extract(
         geom_type,
         config_data,
         centroid,
+        use_st_within,
     )
 
     return JSONResponse(

--- a/src/frontend/src/components/CreateProject/04-MapData.tsx
+++ b/src/frontend/src/components/CreateProject/04-MapData.tsx
@@ -124,6 +124,7 @@ const MapData = () => {
 
     dataExtractRequestFormData.append('geojson_file', projectAoiGeojsonFile);
     dataExtractRequestFormData.append('osm_category', values.osm_category);
+    dataExtractRequestFormData.append('use_st_within', (!values.use_st_within)?.toString() ?? 'false');
     dataExtractRequestFormData.append('geom_type', values.primary_geom_type as GeoGeomTypesEnum);
     if (values.primary_geom_type == GeoGeomTypesEnum.POINT)
       dataExtractRequestFormData.append('centroid', values.includeCentroid ? 'true' : 'false');
@@ -297,18 +298,38 @@ const MapData = () => {
       )}
 
       {values.dataExtractType === 'osm_data_extract' && (
-        <div className="fmtm-flex fmtm-flex-col fmtm-gap-1">
-          <Button
-            variant="primary-red"
-            onClick={() => {
-              resetMapDataFile();
-              generateDataExtract();
-            }}
-            isLoading={fetchingOSMData}
-          >
-            Fetch OSM Data
-          </Button>
-        </div>
+        <>
+          <div className="fmtm-flex fmtm-items-center fmtm-gap-2">
+            <FieldLabel label="Allow Features that intersect the AOI" />
+            <Controller
+              control={control}
+              name="use_st_within"
+              render={({ field }) => (
+                <Switch
+                  ref={field.ref}
+                  checked={field.value}
+                  onCheckedChange={(value) => {
+                    field.onChange(value);
+                    setValue('use_st_within', value);
+                  }}
+                  className=""
+                />
+              )}
+            />
+          </div>
+          <div className="fmtm-flex fmtm-flex-col fmtm-gap-1">
+            <Button
+              variant="primary-red"
+              onClick={() => {
+                resetMapDataFile();
+                generateDataExtract();
+              }}
+              isLoading={fetchingOSMData}
+            >
+              Fetch OSM Data
+            </Button>
+          </div>
+        </>
       )}
 
       {values.dataExtractType === 'custom_data_extract' && (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2325 
- #1220 

## Describe this PR

This PR introduces support for selecting how OSM features are clipped to the Area of Interest (AOI), offering more flexibility in extract generation.

1. Backend Update

 - Added a new parameter: use_st_within which Controls the clipping behavior during extract generation (ST_WITHIN True by default)

2. Clipping Mode Options

 - ST_WITHIN: Includes only features completely inside the AOI

 - ST_INTERSECTS: Includes features that touch or overlap the AOI boundary

3. UI Update

 - When "Fetch data from OSM" is selected as the data source: A toggle is displayed allowing the user to switch between ST_WITHIN and ST_INTERSECTS modes


## Screenshots
<img width="847" height="530" alt="image" src="https://github.com/user-attachments/assets/328a40e5-eed8-475d-9f17-f852469cf654" />
<img width="609" height="316" alt="image" src="https://github.com/user-attachments/assets/5d66953d-75a4-48a0-89d4-3039c80692d5" />



## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
