### PR TITLE
Project metadata within QGIS created projects

### DIFF
--- a/src/backend/app/qfield/qfield_crud.py
+++ b/src/backend/app/qfield/qfield_crud.py
@@ -564,6 +564,7 @@ async def create_qfield_project(
             qfc_project_name = _sanitize_qfc_project_name(raw_qfc_project_name)
             result = await _upload_to_qfieldcloud(
                 project=project,
+                description=qgis_project_description,
                 qfc_project_name=qfc_project_name,
                 final_project_dir=tmp_dir,
                 custom_qfield_creds=custom_qfield_creds,
@@ -966,6 +967,7 @@ async def _create_qfc_user(username: str, password: str, client) -> bool:
 async def _upload_to_qfieldcloud(
     *,
     project: DbProject,
+    description: str,
     qfc_project_name: str,
     final_project_dir: str,
     custom_qfield_creds: QFieldCloud | None,
@@ -989,7 +991,7 @@ async def _upload_to_qfieldcloud(
                 client.create_project,
                 qfc_project_name,
                 owner=qfc_owner,
-                description="Created by the Field Tasking Manager",
+                description=description,
                 is_public=True,
             ),
         )

--- a/src/backend/app/qfield/qfield_crud.py
+++ b/src/backend/app/qfield/qfield_crud.py
@@ -518,6 +518,11 @@ async def create_qfield_project(
 
     # ── Step 1: Write job inputs to DB and call QGIS wrapper ─────────
     qgis_project_title = project.project_name or f"project-{project.id}"
+    qgis_project_description = (
+        project.description or "Created by the Field Tasking Manager"
+    )
+    qgis_project_author = project.created_by_sub or "Field Tasking Manager"
+
     job_id = uuid4()
     await _insert_qgis_job(db, job_id, xlsform_bytes, features_geojson, tasks_geojson)
     await db.commit()
@@ -526,6 +531,8 @@ async def create_qfield_project(
         await _call_qgis_wrapper(
             job_id=str(job_id),
             title=qgis_project_title,
+            description=qgis_project_description,
+            author=qgis_project_author,
             language=form_language or "",
             extent=bbox_str,
             open_in_edit_mode=open_in_edit_mode,
@@ -602,6 +609,8 @@ async def attach_basemap_to_qfield_project(
         await _call_qgis_wrapper(
             job_id=str(job_id),
             title=project.project_name or f"project-{project.id}",
+            description=project.description or "Created by the Field Tasking Manager",
+            author=project.created_by_sub or "Field Tasking Manager",
             language="",
             extent="0,0,0,0",
             open_in_edit_mode=False,
@@ -807,10 +816,12 @@ async def _wait_for_projectfile_processing(
     )
 
 
-async def _call_qgis_wrapper(
+async def _call_qgis_wrapper(  # noqa: PLR0913
     *,
     job_id: str,
     title: str,
+    description: str,
+    author: str,
     language: str,
     extent: str,
     open_in_edit_mode: bool,
@@ -827,6 +838,8 @@ async def _call_qgis_wrapper(
     payload = {
         "job_id": job_id,
         "title": title,
+        "description": description,
+        "author": author,
         "language": language,
         "extent": extent,
         "open_in_edit_mode": open_in_edit_mode,

--- a/src/backend/tests/test_qfield_routes.py
+++ b/src/backend/tests/test_qfield_routes.py
@@ -417,6 +417,8 @@ async def test_attach_basemap_to_qfield_project_inserts_job_with_basemap_url(
         id=7,
         external_project_id="qfc-123",
         project_name="demo",
+        description="description",
+        created_by_sub="user",
         external_project_instance_url=None,
         external_project_username=None,
         external_project_password_encrypted=None,
@@ -497,6 +499,8 @@ async def test_create_qfield_project_passes_resolved_language_to_qgis_wrapper(
     project = SimpleNamespace(
         id=11,
         project_name="demo",
+        description="description",
+        created_by_sub="user",
         outline={
             "type": "Feature",
             "geometry": {"type": "Point", "coordinates": [85.3, 27.7]},

--- a/src/qfield/field_project.py
+++ b/src/qfield/field_project.py
@@ -508,6 +508,8 @@ def generate_qgis_project(
     open_in_edit_mode: bool,
     log: logging.Logger,
     plugin_zip: Optional[bytes] = None,
+    description: Optional[str] = "",
+    author: Optional[str] = "",
 ) -> Dict[str, Any]:
     """Generate QGIS project using input files from the database.
 
@@ -548,6 +550,13 @@ def generate_qgis_project(
         _normalize_root_layer_order(project, log)
 
         _apply_plugin_and_styles(project, plugin_zip, final_output_dir, project_file, log)
+
+        # Add metadata details
+        project_metadata = project.metadata()
+        project_metadata.setTitle(title)
+        project_metadata.setAbstract(description)
+        project_metadata.setAuthor(author)
+        project.setMetadata(project_metadata)
 
         # Finalise the project
         project.write()

--- a/src/qfield/server.py
+++ b/src/qfield/server.py
@@ -76,6 +76,8 @@ class QGISRequestHandler(BaseHTTPRequestHandler):
                     "db_url": db_url,
                     "job_id": data["job_id"],
                     "title": data["title"],
+                    "description": data.get("description", ""),
+                    "author": data.get("author", ""),
                     "language": data["language"],
                     "extent": data["extent"],
                     "open_in_edit_mode": parse_bool(data.get("open_in_edit_mode"), True),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

The PR adds basic metadata details - title, abstract aka description, and author - to the generated QGIS project. Beyond safeguarding crucial bits of information within the QGIS project file itself, it adds a nice bit of polish when used with QField >= 4.2 as the app now exposes these details.

Here's how it looks in QField:

https://github.com/user-attachments/assets/6adf3c8d-0123-4f4c-8a3c-0c9af11afe60

I've also made a tweak to the QFieldCloud project container creation to rely on the project description instead of the static "Created by the Field Tasking Manager" string. Starting with QField 4.2, it will make for a much nicer HOTOSM cloud projects list as the description is (finally :wink:) used in the UI.

Here's how that looks (with the static string):

<img width="399" height="722" alt="image" src="https://github.com/user-attachments/assets/1eb3aba7-d11f-44fc-8ee6-786bc9ebeb71" />

That will look dramatically better with actual user-provided descriptions.


## AI Tool Usage

- [x] No AI tools were used
- [ ] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used:
- What was generated:
- What you reviewed and changed:

## Screenshots

If applicable.

## Alternative Approaches Considered

Did you consider other approaches? Why this one?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [ ] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [ ] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [ ] Related docs and screenshots are updated
