### PR TITLE
Add default expression to the survey layer's status attribute to drive symbology

### DIFF
--- a/src/qfield/field_project.py
+++ b/src/qfield/field_project.py
@@ -224,7 +224,7 @@ def _add_plugin_survey_fields(project, log: logging.Logger) -> None:
     ('mapped', 'invalid', or empty/null for the default unmapped style)
     and reads it to decide when a task is complete.
     """
-    from qgis.core import QgsField
+    from qgis.core import QgsDefaultValue, QgsField
     from qgis.PyQt.QtCore import QMetaType
 
     layers = project.mapLayersByName("survey")
@@ -233,23 +233,31 @@ def _add_plugin_survey_fields(project, log: logging.Logger) -> None:
         return
     layer = layers[0]
 
-    if layer.fields().indexOf("status") >= 0:
-        log.debug("Survey layer already has 'status' field; skipping")
-        return
-
-    if not layer.startEditing():
-        log.warning("Could not start editing survey layer to add plugin fields")
-        return
-    layer.addAttribute(QgsField("status", QMetaType.Type.QString))
-
     status_idx = layer.fields().indexOf("status")
-    for feature in layer.getFeatures():
-        layer.changeAttributeValue(feature.id(), status_idx, "")
-
-    if not layer.commitChanges():
-        log.warning("Failed to commit plugin fields to survey layer")
+    if status_idx == -1:
+        if not layer.startEditing():
+            log.warning("Could not start editing survey layer to add plugin fields")
+            return
+        layer.addAttribute(QgsField("status", QMetaType.Type.QString))
+    
+        status_idx = layer.fields().indexOf("status")
+        for feature in layer.getFeatures():
+            layer.changeAttributeValue(feature.id(), status_idx, "")
+    
+        if not layer.commitChanges():
+            log.warning("Failed to commit plugin fields to survey layer")
+            return    
+        log.info("Added status field to survey layer")
+    else:
+        log.debug("Survey layer already has 'status' field; skipping creation")
         return
-    log.info("Added status field to survey layer")
+
+    layer.setDefaultValueDefinition(
+        status_idx,
+        QgsDefaultValue(
+            'if("status" is null or "status" = \'\', \'mapped\', "status")', True
+        ),
+    )
 
 
 def _load_generated_project(project_file: str):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

This PR adds the required default expression driving the status attribute value for a given survey layer within a generated QGIS project.

## AI Tool Usage

- [x] No AI tools were used
- [ ] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used:
- What was generated:
- What you reviewed and changed:

## Screenshots

If applicable.

## Alternative Approaches Considered

Did you consider other approaches? Why this one?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [ ] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [ ] Related docs and screenshots are updated
