### PR TITLE
fix(backend): repair multipart upload binding on helper routes + add route tests (#2232)

### DIFF
--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -22,6 +22,7 @@ import json
 import logging
 from io import BytesIO, StringIO
 from pathlib import Path
+from typing import Annotated
 from uuid import uuid4
 
 import requests
@@ -30,7 +31,9 @@ from litestar import Request, Response, Router, get, post
 from litestar import status_codes as status
 from litestar.datastructures import UploadFile
 from litestar.di import Provide
+from litestar.enums import RequestEncodingType
 from litestar.exceptions import HTTPException
+from litestar.params import Body, Parameter
 from osm_fieldwork.conversion_to_xlsform import convert_to_xlsform
 from osm_fieldwork.xlsforms import xlsforms_path
 
@@ -87,11 +90,11 @@ async def download_template(
     dependencies={"current_user": Provide(login_required)},
 )
 async def convert_geojson_to_odk_csv_wrapper(
-    geojson: UploadFile,
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     current_user: object,
 ) -> Response[bytes]:
     """Convert GeoJSON upload media to ODK CSV upload media."""
-    filename = Path(geojson.filename)
+    filename = Path(data.filename)
     file_ext = filename.suffix.lower()
 
     allowed_extensions = [".json", ".geojson"]
@@ -101,7 +104,7 @@ async def convert_geojson_to_odk_csv_wrapper(
             detail=_("Provide a valid .json or .geojson file"),
         )
 
-    contents = await geojson.read()
+    contents = await data.read()
     feature_csv = await convert_geojson_to_odk_csv(BytesIO(contents))
 
     headers = {"Content-Disposition": f"attachment; filename={filename.stem}.csv"}
@@ -119,18 +122,25 @@ async def convert_geojson_to_odk_csv_wrapper(
     },
 )
 async def create_entities_from_csv(
-    csv_file: UploadFile,
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     odk_project_id: int,
     entity_name: str,
     current_user: object,
-    odk_creds: ODKCentral,
+    external_project_instance_url: str | None = Parameter(default=None),
+    external_project_username: str | None = Parameter(default=None),
+    external_project_password: str | None = Parameter(default=None),
 ) -> dict:
     """Upload a CSV file to create new ODK Entities in a project.
 
     The Entity must already be defined on the server.
     The CSV fields must match the Entity fields.
     """
-    filename = Path(csv_file.filename)
+    odk_creds = ODKCentral(
+        external_project_instance_url=external_project_instance_url,
+        external_project_username=external_project_username,
+        external_project_password=external_project_password,
+    )
+    filename = Path(data.filename)
     file_ext = filename.suffix.lower()
 
     if file_ext != ".csv":
@@ -144,7 +154,7 @@ async def create_entities_from_csv(
         csv_reader = csv.DictReader(StringIO(csv_str))
         return [dict(row) for row in csv_reader]
 
-    parsed_data = parse_csv(await csv_file.read())
+    parsed_data = parse_csv(await data.read())
     entities_data_dict = {str(uuid4()): data for data in parsed_data}
 
     async with central_deps.get_odk_dataset(odk_creds) as odk_central:
@@ -175,7 +185,7 @@ async def convert_javarosa_geom_to_geojson(
     dependencies={"current_user": Provide(login_required)},
 )
 async def convert_odk_submission_json_to_geojson_wrapper(
-    json_file: UploadFile,
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     current_user: object,
 ) -> Response[bytes]:
     """Convert the ODK submission output JSON to GeoJSON.
@@ -183,7 +193,7 @@ async def convert_odk_submission_json_to_geojson_wrapper(
     The submission JSON be downloaded via ODK Central, or osm-fieldwork.
     The logic works with the standardised XForm form fields from osm-fieldwork.
     """
-    filename = Path(json_file.filename)
+    filename = Path(data.filename)
     file_ext = filename.suffix.lower()
 
     allowed_extensions = [".json"]
@@ -193,7 +203,7 @@ async def convert_odk_submission_json_to_geojson_wrapper(
             detail=_("Provide a valid .json file"),
         )
 
-    contents = await json_file.read()
+    contents = await data.read()
     submission_geojson = await convert_odk_submission_json_to_geojson(BytesIO(contents))
     submission_data = BytesIO(json.dumps(submission_geojson).encode("utf-8"))
 
@@ -241,11 +251,11 @@ async def get_raw_data_api_osm_token(
     dependencies={"current_user": Provide(login_required)},
 )
 async def flatten_multipolygons_to_polygons(
-    geojson: UploadFile,
+    data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)],
     current_user: object,
 ) -> Response[bytes]:
     """If any MultiPolygons are present, replace with multiple Polygons."""
-    featcol = parse_aoi(settings.FTM_DB_URL, await geojson.read())
+    featcol = parse_aoi(settings.FTM_DB_URL, await data.read())
     if not featcol:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -155,7 +155,7 @@ async def create_entities_from_csv(
         return [dict(row) for row in csv_reader]
 
     parsed_data = parse_csv(await data.read())
-    entities_data_dict = {str(uuid4()): data for data in parsed_data}
+    entities_data_dict = {str(uuid4()): row for row in parsed_data}
 
     async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         create_success = await odk_central.createEntities(

--- a/src/backend/tests/test_helper_routes.py
+++ b/src/backend/tests/test_helper_routes.py
@@ -17,11 +17,73 @@
 #
 """Tests for helper routes."""
 
-from unittest.mock import AsyncMock, patch
+import csv
+import json
+from io import StringIO
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from app.central.central_routes import odk_creds_test
+
+HELPERS_PREFIX = "/api/v1/helpers"
+
+# A single Polygon AOI around Kathmandu
+_POLYGON_FEATCOL = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [85.299989110, 27.7140080437],
+                        [85.299989110, 27.7108923499],
+                        [85.304783157, 27.7108923499],
+                        [85.304783157, 27.7140080437],
+                        [85.299989110, 27.7140080437],
+                    ]
+                ],
+            },
+        }
+    ],
+}
+
+# Two disjoint polygons as a single MultiPolygon feature
+_MULTIPOLYGON_FEATCOL = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [85.299989110, 27.7140080437],
+                            [85.299989110, 27.7108923499],
+                            [85.304783157, 27.7108923499],
+                            [85.304783157, 27.7140080437],
+                            [85.299989110, 27.7140080437],
+                        ]
+                    ],
+                    [
+                        [
+                            [85.317028828, 27.7052522097],
+                            [85.317028828, 27.7041424888],
+                            [85.318844411, 27.7041424888],
+                            [85.318844411, 27.7052522097],
+                            [85.317028828, 27.7052522097],
+                        ]
+                    ],
+                ],
+            },
+        }
+    ],
+}
 
 
 async def test_helper_odk_creds_test():
@@ -37,6 +99,309 @@ async def test_helper_odk_creds_test():
         )
 
     mock_test_odk.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /download-template-xlsform
+# ---------------------------------------------------------------------------
+
+
+async def test_download_template_xlsform_success(client):
+    """A bundled XLSForm template should download as a valid XLSX file."""
+    response = await client.get(
+        f"{HELPERS_PREFIX}/download-template-xlsform",
+        params={"form_type": "OSM Buildings"},
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers["content-disposition"] == "attachment; filename=buildings.xlsx"
+    )
+    assert response.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    # XLSX files are zip archives, which always start with the PK magic bytes
+    assert response.content[:2] == b"PK"
+
+
+async def test_download_template_xlsform_invalid_form_type(client):
+    """An unknown form_type should be rejected by enum validation."""
+    response = await client.get(
+        f"{HELPERS_PREFIX}/download-template-xlsform",
+        params={"form_type": "not-a-real-form"},
+    )
+
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /convert-geojson-to-odk-csv
+# ---------------------------------------------------------------------------
+
+
+async def test_convert_geojson_to_odk_csv_success(client):
+    """A valid GeoJSON upload should convert to ODK CSV upload media."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/convert-geojson-to-odk-csv",
+        files={
+            "geojson": (
+                "features.geojson",
+                json.dumps(_POLYGON_FEATCOL).encode("utf-8"),
+                "application/geo+json",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers["content-disposition"] == "attachment; filename=features.csv"
+    )
+
+    rows = list(csv.DictReader(StringIO(response.text)))
+    assert len(rows) == 1
+    expected_columns = {
+        "osm_id",
+        "tags",
+        "version",
+        "changeset",
+        "timestamp",
+        "geometry",
+    }
+    assert expected_columns.issubset(rows[0].keys())
+    # Geometry must be converted to JavaRosa format (lat lon alt acc; ...)
+    assert rows[0]["geometry"]
+    first_point = rows[0]["geometry"].split(";")[0].split()
+    assert len(first_point) == 4
+
+
+async def test_convert_geojson_to_odk_csv_invalid_extension(client):
+    """A non-GeoJSON file extension should be rejected."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/convert-geojson-to-odk-csv",
+        files={"geojson": ("features.txt", b"not geojson", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "valid .json or .geojson" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /create-entities-from-csv
+# ---------------------------------------------------------------------------
+
+
+async def test_create_entities_from_csv_success(client):
+    """A valid CSV upload should create ODK Entities via Central."""
+    mock_odk_central = AsyncMock()
+    mock_odk_central.createEntities.return_value = {"success": True}
+    mock_dataset_ctx = MagicMock()
+    mock_dataset_ctx.__aenter__.return_value = mock_odk_central
+
+    with patch(
+        "app.helpers.helper_routes.central_deps.get_odk_dataset",
+        return_value=mock_dataset_ctx,
+    ):
+        response = await client.post(
+            f"{HELPERS_PREFIX}/create-entities-from-csv",
+            params={"odk_project_id": 1, "entity_name": "features"},
+            files={
+                "data": ("entities.csv", b"label,status\nfeature1,ready", "text/csv")
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json() == {"success": True}
+    mock_odk_central.createEntities.assert_awaited_once()
+    # One CSV row should map to exactly one entity, keyed by generated UUID
+    _, entity_name, entities = mock_odk_central.createEntities.await_args.args
+    assert entity_name == "features"
+    assert list(entities.values()) == [{"label": "feature1", "status": "ready"}]
+
+
+async def test_create_entities_from_csv_invalid_extension(client):
+    """A non-CSV file extension should be rejected."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/create-entities-from-csv",
+        params={"odk_project_id": 1, "entity_name": "features"},
+        files={"data": ("entities.txt", b"label\nfeature1", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "valid .csv" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /javarosa-geom-to-geojson
+# ---------------------------------------------------------------------------
+
+
+async def test_javarosa_geom_to_geojson_point(client):
+    """A single JavaRosa point should convert to a GeoJSON Point."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/javarosa-geom-to-geojson",
+        params={"javarosa_string": "27.7108923499 85.2999891100 0.0 0.0"},
+    )
+
+    assert response.status_code == 201
+    geometry = response.json()
+    assert geometry["type"] == "Point"
+    assert geometry["coordinates"] == [85.29998911, 27.7108923499]
+
+
+async def test_javarosa_geom_to_geojson_polygon(client):
+    """A closed JavaRosa coordinate loop should convert to a GeoJSON Polygon."""
+    javarosa_string = (
+        "27.7140080437 85.2999891100 0.0 0.0;"
+        "27.7108923499 85.2999891100 0.0 0.0;"
+        "27.7108923499 85.3047831570 0.0 0.0;"
+        "27.7140080437 85.2999891100 0.0 0.0"
+    )
+    response = await client.post(
+        f"{HELPERS_PREFIX}/javarosa-geom-to-geojson",
+        params={"javarosa_string": javarosa_string},
+    )
+
+    assert response.status_code == 201
+    geometry = response.json()
+    assert geometry["type"] == "Polygon"
+    # One ring, closed (first == last)
+    assert len(geometry["coordinates"]) == 1
+    assert geometry["coordinates"][0][0] == geometry["coordinates"][0][-1]
+
+
+# ---------------------------------------------------------------------------
+# POST /convert-odk-submission-json-to-geojson
+# ---------------------------------------------------------------------------
+
+
+async def test_convert_odk_submission_json_to_geojson_success(client):
+    """An ODK submission JSON list should convert to a GeoJSON download."""
+    submission = [
+        {
+            "meta": {"instanceID": "uuid:test"},
+            "__id": "uuid:test",
+            "__system": {"submitterId": "1"},
+            "xlocation": "27.7108923499 85.2999891100 0.0 0.0",
+            "status": "complete",
+        }
+    ]
+    response = await client.post(
+        f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
+        files={
+            "json_file": (
+                "submissions.json",
+                json.dumps(submission).encode("utf-8"),
+                "application/json",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers["content-disposition"]
+        == "attachment; filename=submissions.geojson"
+    )
+
+    geojson = json.loads(response.content)
+    assert geojson["type"] == "FeatureCollection"
+    assert len(geojson["features"]) == 1
+    feature = geojson["features"][0]
+    assert feature["geometry"]["type"] == "Point"
+    assert feature["properties"]["status"] == "complete"
+
+
+async def test_convert_odk_submission_json_to_geojson_invalid_extension(client):
+    """A non-JSON file extension should be rejected."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
+        files={"json_file": ("submissions.csv", b"a,b,c", "text/csv")},
+    )
+
+    assert response.status_code == 400
+    assert "valid .json" in response.text
+
+
+async def test_convert_odk_submission_json_to_geojson_empty(client):
+    """An empty submission list should return 422 (no submissions yet)."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
+        files={
+            "json_file": ("submissions.json", b"[]", "application/json"),
+        },
+    )
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /view-raw-data-api-token
+# ---------------------------------------------------------------------------
+
+
+async def test_view_raw_data_api_token_redirects(client):
+    """A successful raw-data-api login should redirect to the login URL."""
+    mock_response = Mock()
+    mock_response.ok = True
+    mock_response.json.return_value = {"login_url": "https://example.com/osm-login"}
+
+    with patch(
+        "app.helpers.helper_routes.requests.get", return_value=mock_response
+    ) as mock_get:
+        response = await client.get(
+            f"{HELPERS_PREFIX}/view-raw-data-api-token",
+            follow_redirects=False,
+        )
+
+    mock_get.assert_called_once()
+    assert response.status_code == 307
+    assert response.headers["location"] == "https://example.com/osm-login"
+
+
+async def test_view_raw_data_api_token_upstream_failure(client):
+    """A failed raw-data-api login should return a 500 error."""
+    mock_response = Mock()
+    mock_response.ok = False
+
+    with patch("app.helpers.helper_routes.requests.get", return_value=mock_response):
+        response = await client.get(
+            f"{HELPERS_PREFIX}/view-raw-data-api-token",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 500
+    assert "Could not login" in response.text
+
+
+# ---------------------------------------------------------------------------
+# POST /multipolygons-to-polygons
+# ---------------------------------------------------------------------------
+
+
+async def test_multipolygons_to_polygons_success(client):
+    """MultiPolygon geometries should be flattened to individual Polygons."""
+    response = await client.post(
+        f"{HELPERS_PREFIX}/multipolygons-to-polygons",
+        files={
+            "geojson": (
+                "aoi.geojson",
+                json.dumps(_MULTIPOLYGON_FEATCOL).encode("utf-8"),
+                "application/geo+json",
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers["content-disposition"]
+        == "attachment; filename=flattened_polygons.geojson"
+    )
+
+    featcol = json.loads(response.content)
+    assert featcol["type"] == "FeatureCollection"
+    assert len(featcol["features"]) >= 1
+    assert all(
+        feature["geometry"]["type"] == "Polygon" for feature in featcol["features"]
+    )
 
 
 if __name__ == "__main__":

--- a/src/backend/tests/test_helper_routes.py
+++ b/src/backend/tests/test_helper_routes.py
@@ -155,7 +155,7 @@ async def test_convert_geojson_to_odk_csv_success(client):
     response = await client.post(
         f"{HELPERS_PREFIX}/convert-geojson-to-odk-csv",
         files={
-            "geojson": (
+            "data": (
                 "features.geojson",
                 json.dumps(_POLYGON_FEATCOL).encode("utf-8"),
                 "application/geo+json",
@@ -189,7 +189,7 @@ async def test_convert_geojson_to_odk_csv_invalid_extension(client):
     """A non-GeoJSON file extension should be rejected."""
     response = await client.post(
         f"{HELPERS_PREFIX}/convert-geojson-to-odk-csv",
-        files={"geojson": ("features.txt", b"not geojson", "text/plain")},
+        files={"data": ("features.txt", b"not geojson", "text/plain")},
     )
 
     assert response.status_code == 400
@@ -299,7 +299,7 @@ async def test_convert_odk_submission_json_to_geojson_success(client):
     response = await client.post(
         f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
         files={
-            "json_file": (
+            "data": (
                 "submissions.json",
                 json.dumps(submission).encode("utf-8"),
                 "application/json",
@@ -325,7 +325,7 @@ async def test_convert_odk_submission_json_to_geojson_invalid_extension(client):
     """A non-JSON file extension should be rejected."""
     response = await client.post(
         f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
-        files={"json_file": ("submissions.csv", b"a,b,c", "text/csv")},
+        files={"data": ("submissions.csv", b"a,b,c", "text/csv")},
     )
 
     assert response.status_code == 400
@@ -337,7 +337,7 @@ async def test_convert_odk_submission_json_to_geojson_empty(client):
     response = await client.post(
         f"{HELPERS_PREFIX}/convert-odk-submission-json-to-geojson",
         files={
-            "json_file": ("submissions.json", b"[]", "application/json"),
+            "data": ("submissions.json", b"[]", "application/json"),
         },
     )
 
@@ -393,7 +393,7 @@ async def test_multipolygons_to_polygons_success(client):
     response = await client.post(
         f"{HELPERS_PREFIX}/multipolygons-to-polygons",
         files={
-            "geojson": (
+            "data": (
                 "aoi.geojson",
                 json.dumps(_MULTIPOLYGON_FEATCOL).encode("utf-8"),
                 "application/geo+json",

--- a/src/backend/tests/test_helper_routes.py
+++ b/src/backend/tests/test_helper_routes.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from app.central.central_routes import odk_creds_test
+from app.config import settings
 
 HELPERS_PREFIX = "/api/v1/helpers"
 
@@ -86,6 +87,16 @@ _MULTIPOLYGON_FEATCOL = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _local_admin_auth(monkeypatch):
+    """Route requests through the debug local-admin auth path.
+
+    The helper routes depend on login_required, which otherwise needs a
+    live hotosm-auth session cookie.
+    """
+    monkeypatch.setattr(settings, "DEBUG", True)
+
+
 async def test_helper_odk_creds_test():
     """The surviving ODK JSON route should still validate credentials."""
     with patch(
@@ -131,7 +142,7 @@ async def test_download_template_xlsform_invalid_form_type(client):
         params={"form_type": "not-a-real-form"},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 422
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #2232 (partially — helper routes covered; other modules can follow in separate PRs)

## Describe this PR

While adding test coverage for the `/api/v1/helpers` routes (per #2232), I found that **all four file-upload helper endpoints are currently broken**: Litestar does not bind bare `UploadFile` handler params from multipart bodies — it treats them as required *query* parameters, so any real upload returns `400: Missing required query parameter`:

- `POST /helpers/convert-geojson-to-odk-csv`
- `POST /helpers/create-entities-from-csv`
- `POST /helpers/convert-odk-submission-json-to-geojson`
- `POST /helpers/multipolygons-to-polygons`

This PR fixes the binding using the same pattern already used by the htmx setup-step routes (`data: Annotated[UploadFile, Body(media_type=RequestEncodingType.MULTI_PART)]`), and passes ODK credentials on `create-entities-from-csv` as individual query params, matching the existing `/central/test-credentials` route (the `ODKCentral` model param had the same binding problem).

It then adds **14 route tests** covering success and failure paths for all 7 helper endpoints, asserting status codes, headers (Content-Disposition / media types), and essential response fields:

- `download-template-xlsform`: valid XLSX bytes + headers; invalid enum → 422
- `convert-geojson-to-odk-csv`: CSV columns + JavaRosa geometry format; bad extension → 400
- `create-entities-from-csv`: entity creation (ODK dataset mocked) incl. payload shape; bad extension → 400
- `javarosa-geom-to-geojson`: Point and closed-loop Polygon conversion
- `convert-odk-submission-json-to-geojson`: GeoJSON output fields; bad extension → 400; empty list → 422
- `view-raw-data-api-token`: 307 + Location on success; upstream failure → 500
- `multipolygons-to-polygons`: MultiPolygon flattened to Polygons

Since CI runs with `DEBUG=False`, the tests authenticate via the app's own debug local-admin path (`settings.DEBUG` toggled per-test with `monkeypatch`) — no auth code was changed.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code (commits carry the `Assisted-by: Claude Code` trailer per AGENTS.md)
- What was generated: the multipart binding fix, all 14 tests, and the litestar binding diagnosis (verified first in an isolated litestar 2.21.1 reproduction)
- What you reviewed and changed: diff reviewed by the submitting human; verified against the full docker test stack via GitHub Actions (see Review Guide)

## Screenshots

N/A — backend fix + tests.

## Alternative Approaches Considered

- Calling handlers via `.fn()` with mocked deps (the `test_basemap_routes` pattern) was considered, but real HTTP requests through the test client are required to actually catch the multipart binding bug — which is exactly the class of bug that was present.
- For ODK creds on `create-entities-from-csv`, a structured body was considered, but individual query params match the existing `/central/test-credentials` precedent.

## Review Guide

- `just test backend` — verified on a fork with Actions enabled: [branch run](https://github.com/ShawK91/field-tm/actions/runs/27299883028) = **17 failed / 350 passed** vs [unmodified dev baseline](https://github.com/ShawK91/field-tm/actions/runs/27298500784) = **17 failed / 336 passed**. The 17 failures are identical pre-existing dev failures (6 htmx project-create, 9 `test_qfield_project_gen_svc` hitting `ImportError: cannot import name 'register_plugin_data_dirs'` from a bare `from utils import …` in `src/qfield/drone_project.py`, 1 api-key auth, 1 project-detail) — happy to look at those in a follow-up.
- The binding bug can be reproduced standalone: a litestar 2.21.1 handler with a bare `UploadFile` param rejects any multipart upload with `400: Missing required query parameter`.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [x] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [x] Related docs and screenshots are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
