### PR TITLE
feat: task assignment UI for project managers (#3095)

### DIFF
--- a/src/backend/app/helpers/geometry_utils.py
+++ b/src/backend/app/helpers/geometry_utils.py
@@ -160,6 +160,54 @@ def get_featcol_dominant_geom_type(featcol: dict) -> str:
     return max(geometry_counts, key=lambda key: geometry_counts[key])
 
 
+def _valid_task_id(task_id) -> bool:
+    """A valid task id is a positive integer (bools excluded)."""
+    return isinstance(task_id, int) and not isinstance(task_id, bool) and task_id > 0
+
+
+def stamp_missing_task_ids(featcol: dict) -> dict:
+    """Stamp a stable integer ``task_id`` onto features lacking a valid one.
+
+    A valid id is a unique positive integer; digit-strings are normalized to
+    int in place. Features whose id is missing, malformed (non-int, zero,
+    negative, bool), or a duplicate of an earlier feature's id are re-stamped
+    with the smallest unused positive integers (starting from 1), so the
+    collection always ends up with unique integer ids.
+    """
+    features = featcol.get("features", []) if isinstance(featcol, dict) else []
+
+    # First pass: normalize digit-strings and reserve valid first-seen ids
+    existing_ids = set()
+    for feature in features:
+        properties = feature.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+            feature["properties"] = properties
+        task_id = properties.get("task_id")
+        if isinstance(task_id, str) and task_id.isdigit():
+            task_id = int(task_id)
+            properties["task_id"] = task_id
+        if _valid_task_id(task_id):
+            existing_ids.add(task_id)
+
+    # Second pass: re-stamp anything missing, malformed, or duplicated
+    next_id = 1
+    seen_ids = set()
+    for feature in features:
+        properties = feature["properties"]
+        task_id = properties.get("task_id")
+        if _valid_task_id(task_id) and task_id not in seen_ids:
+            seen_ids.add(task_id)
+            continue
+        while next_id in existing_ids:
+            next_id += 1
+        properties["task_id"] = next_id
+        existing_ids.add(next_id)
+        seen_ids.add(next_id)
+
+    return featcol
+
+
 async def check_crs(  # noqa: C901
     input_geojson: dict,
 ):

--- a/src/backend/app/htmx/assignment/__init__.py
+++ b/src/backend/app/htmx/assignment/__init__.py
@@ -1,0 +1,1 @@
+"""HTMX task assignment route modules."""

--- a/src/backend/app/htmx/assignment/assignment_routes.py
+++ b/src/backend/app/htmx/assignment/assignment_routes.py
@@ -1,0 +1,333 @@
+# Copyright (c) Humanitarian OpenStreetMap Team
+#
+# This file is part of Field-TM.
+#
+#     Field-TM is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     Field-TM is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with Field-TM.  If not, see <https:#www.gnu.org/licenses/>.
+#
+
+"""Task assignment HTMX routes.
+
+Manager-facing panel for assigning task areas to mappers in advance.
+Assignments are stored as ``assigned_to`` / ``assigned_group`` feature
+properties inside the existing ``projects.task_areas_geojson`` JSONB;
+task ``status`` is owned by the field apps and is never written here.
+"""
+
+import json
+import logging
+from asyncio import get_running_loop
+from functools import partial
+
+from litestar import get, post
+from litestar import status_codes as status
+from litestar.di import Provide
+from litestar.enums import RequestEncodingType
+from litestar.params import Body, Parameter
+from litestar.plugins.htmx import HTMXRequest
+from litestar.response import Response, Template
+from psycopg import AsyncConnection
+
+from app.auth.auth_deps import login_required
+from app.auth.auth_schemas import ProjectUserDict
+from app.auth.roles import project_manager
+from app.db.database import db_conn
+from app.db.enums import FieldMappingApp
+from app.db.models import DbProject
+from app.helpers.geometry_utils import stamp_missing_task_ids
+from app.i18n import _
+from app.projects.project_services import (
+    ServiceError,
+    save_task_assignments,
+)
+from app.qfield.qfield_deps import qfield_client
+from app.qfield.qfield_utils import is_default_qfc_instance_url
+
+from ..setup_steps.setup_step_parsing import (
+    parse_json_payload as _parse_json_payload,
+)
+from ..setup_steps.setup_step_responses import (
+    authorized_project_or_response as _authorized_project_or_response,
+)
+from ..setup_steps.setup_step_responses import (
+    html_error_response as _html_error_response,
+)
+from ..setup_steps.setup_step_responses import (
+    json_error_response as _json_error_response,
+)
+from ..setup_steps.setup_step_responses import (
+    service_error_response as _service_error_response,
+)
+from ..setup_steps.setup_step_responses import (
+    unexpected_error_response as _unexpected_error_response,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _task_features(task_areas: dict | None) -> list[dict]:
+    """Return the stored task area features (empty for the {} sentinel).
+
+    Stored task_id is authoritative (stamped by save_task_areas); stamp in
+    memory only for legacy rows saved before ids were persisted, mirroring
+    _build_task_entities, so the panel always works with integer ids.
+    """
+    if not isinstance(task_areas, dict):
+        return []
+    features = task_areas.get("features")
+    if not isinstance(features, list):
+        return []
+    if features:
+        stamp_missing_task_ids(task_areas)
+    return features
+
+
+def _summary_rows(task_areas: dict | None) -> list[dict]:
+    """Build summary table rows from stored task area properties."""
+    rows = []
+    for feature in _task_features(task_areas):
+        properties = feature.get("properties") or {}
+        rows.append(
+            {
+                "task_id": properties.get("task_id"),
+                "assigned_to": properties.get("assigned_to", ""),
+                "assigned_group": properties.get("assigned_group", ""),
+                "building_count": properties.get("building_count"),
+            }
+        )
+    rows.sort(key=lambda row: (row["task_id"] is None, row["task_id"]))
+    return rows
+
+
+def _panel_context(
+    project: DbProject, assignee_suggestions: list[str] | None = None
+) -> dict:
+    """Shared template context for the panel and summary fragments."""
+    task_areas = project.task_areas_geojson
+    summary_rows = _summary_rows(task_areas)
+    return {
+        "project_id": project.id,
+        "has_task_areas": bool(summary_rows),
+        "summary_rows": summary_rows,
+        "has_building_counts": any(
+            row["building_count"] is not None for row in summary_rows
+        ),
+        "assignee_suggestions": assignee_suggestions or [],
+    }
+
+
+async def _qfc_assignee_suggestions(project: DbProject) -> list[str]:
+    """Best-effort QFC collaborator names for the assignee datalist.
+
+    Only QField projects on the default QFieldCloud instance have a
+    collaborator list to suggest from (the same source the collaborator
+    form manages); those are the only names that can auto-match in the
+    QField plugin. ODK projects stay free-text-only. Failures are
+    non-fatal - the panel works with an empty datalist.
+    """
+    if (
+        project.field_mapping_app != FieldMappingApp.QFIELD
+        or not project.external_project_id
+        or not is_default_qfc_instance_url(project.external_project_instance_url)
+    ):
+        return []
+    try:
+        loop = get_running_loop()
+        async with qfield_client() as client:
+            collaborators = await loop.run_in_executor(
+                None,
+                partial(
+                    client.get_project_collaborators,
+                    str(project.external_project_id),
+                ),
+            )
+        return sorted(
+            {
+                str(collab.get("collaborator"))
+                for collab in collaborators
+                if collab.get("collaborator")
+            },
+            key=str.lower,
+        )
+    except Exception as e:
+        log.warning(
+            "Could not fetch QFC collaborators for project %s: %s", project.id, e
+        )
+        return []
+
+
+@get(
+    path="/projects/{project_id:int}/assignments-htmx",
+    dependencies={
+        "db": Provide(db_conn),
+        "auth_user": Provide(login_required),
+        "current_user": Provide(project_manager),
+    },
+)
+async def assignment_panel_htmx(
+    request: HTMXRequest,
+    current_user: ProjectUserDict,
+    auth_user: object,
+    project_id: int = Parameter(),
+) -> Response | Template:
+    """Render the lazy-loaded task assignment panel fragment."""
+    project, not_found_response = _authorized_project_or_response(
+        current_user, project_id
+    )
+    if not_found_response:
+        return not_found_response
+
+    assignee_suggestions = await _qfc_assignee_suggestions(project)
+    return Template(
+        template_name="partials/project_details/fragments/assignment_panel.html",
+        context=_panel_context(project, assignee_suggestions),
+        media_type="text/html",
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@get(
+    path="/projects/{project_id:int}/assignments/geojson",
+    dependencies={
+        "db": Provide(db_conn),
+        "auth_user": Provide(login_required),
+        "current_user": Provide(project_manager),
+    },
+)
+async def assignment_geojson(
+    request: HTMXRequest,
+    current_user: ProjectUserDict,
+    auth_user: object,
+    project_id: int = Parameter(),
+) -> Response:
+    """Return the task areas FeatureCollection with assignment properties.
+
+    Consumed by fetch() in the assignment panel JS module, so errors are
+    JSON rather than swapped HTML fragments.
+    """
+    project, not_found_response = _authorized_project_or_response(
+        current_user, project_id
+    )
+    if not_found_response:
+        return _json_error_response(
+            _("Project not found or access denied."),
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    features = _task_features(project.task_areas_geojson)
+    if not features:
+        return _json_error_response(
+            _("No task areas to assign. Split the project area into tasks first."),
+            status.HTTP_404_NOT_FOUND,
+        )
+
+    merged_features = []
+    for feature in features:
+        properties = dict(feature.get("properties") or {})
+        properties.setdefault("assigned_to", "")
+        properties.setdefault("assigned_group", "")
+        merged_features.append({**feature, "properties": properties})
+    feature_collection = {"type": "FeatureCollection", "features": merged_features}
+
+    return Response(
+        content=json.dumps(feature_collection),
+        media_type="application/geo+json",
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@post(
+    path="/projects/{project_id:int}/assignments",
+    dependencies={
+        "db": Provide(db_conn),
+        "auth_user": Provide(login_required),
+        "current_user": Provide(project_manager),
+    },
+)
+async def save_assignments_htmx(
+    request: HTMXRequest,
+    db: AsyncConnection,
+    current_user: ProjectUserDict,
+    auth_user: object,
+    data: dict = Body(media_type=RequestEncodingType.URL_ENCODED),
+    project_id: int = Parameter(),
+) -> Response | Template:
+    """Validate and persist task assignment edits, then refresh the summary."""
+    _project, not_found_response = _authorized_project_or_response(
+        current_user, project_id
+    )
+    if not_found_response:
+        return not_found_response
+
+    try:
+        assignments_str = data.get("assignments", "")
+        if not assignments_str:
+            return _html_error_response(_("No assignments data provided."), 400)
+
+        # No HTML-unescape: the payload is set by JS via JSON.stringify and
+        # never entity-encoded, so unescaping would corrupt legitimate
+        # values (an assignee typed as "Bob &amp; Co" must store verbatim).
+        assignments, error_response = _parse_json_payload(
+            assignments_str,
+            _("Invalid assignments data format."),
+            "Error parsing assignments JSON",
+            unescape=False,
+        )
+        if error_response:
+            return error_response
+
+        updated_count = await save_task_assignments(
+            db=db,
+            project_id=project_id,
+            assignments=assignments,
+        )
+
+        refreshed_project = await DbProject.one(db, project_id)
+        return Template(
+            template_name=(
+                "partials/project_details/fragments/assignment_summary.html"
+            ),
+            context={
+                **_panel_context(refreshed_project),
+                "saved_message": _("✓ Assignments saved"),
+            },
+            media_type="text/html",
+            status_code=status.HTTP_200_OK,
+            headers={
+                "Vary": "HX-Request",
+                "HX-Trigger": json.dumps(
+                    {
+                        "assignment:saved": {
+                            "projectId": project_id,
+                            "updated": updated_count,
+                        }
+                    }
+                ),
+            },
+        )
+
+    except ServiceError as e:
+        return _service_error_response(e)
+    except Exception as e:
+        # Log the detail server-side only; the rendered fragment gets the
+        # generic message so internals (driver errors etc.) never reach
+        # the client.
+        log.error(f"Error saving assignments via HTMX: {e}", exc_info=True)
+        return _unexpected_error_response()
+
+
+ROUTE_HANDLERS = [
+    assignment_panel_htmx,
+    assignment_geojson,
+    save_assignments_htmx,
+]

--- a/src/backend/app/htmx/htmx_routes.py
+++ b/src/backend/app/htmx/htmx_routes.py
@@ -2,6 +2,9 @@
 
 from litestar import Router
 
+from app.htmx.assignment.assignment_routes import (
+    ROUTE_HANDLERS as ASSIGNMENT_HANDLERS,
+)
 from app.htmx.basemap.basemap_routes import ROUTE_HANDLERS as BASEMAP_HANDLERS
 from app.htmx.landing_routes import landing, login_page, metrics_partial
 from app.htmx.project_create.project_create_page_routes import (
@@ -83,5 +86,6 @@ htmx_router = Router(
         *SETUP_STEP_VALIDATE_HANDLERS,
         *QFC_ADMIN_HANDLERS,
         *BASEMAP_HANDLERS,
+        *ASSIGNMENT_HANDLERS,
     ],
 )

--- a/src/backend/app/htmx/project_detail_routes.py
+++ b/src/backend/app/htmx/project_detail_routes.py
@@ -41,11 +41,11 @@ from app.auth.auth_deps import (
     login_required,
 )
 from app.auth.auth_schemas import ProjectUserDict
-from app.auth.roles import project_manager
+from app.auth.roles import check_access, project_manager
 from app.central import central_crud
 from app.config import decrypt_value
 from app.db.database import db_conn
-from app.db.enums import FieldMappingApp
+from app.db.enums import FieldMappingApp, ProjectRole
 from app.db.models import DbProject
 from app.i18n import _
 from app.projects import project_crud
@@ -234,6 +234,29 @@ def _show_qfc_collaborator_form(project: DbProject) -> bool:
     )
 
 
+async def _show_assignment_panel(
+    db: AsyncConnection, auth_user: object | None, project: DbProject
+) -> bool:
+    """Whether the viewer may see the manager-gated task assignment panel.
+
+    Mirrors the project_manager gate on the panel routes so non-managers
+    viewing a published project never trigger the lazy load (the global
+    htmx config would swap the 4xx auth error into the panel slot).
+    """
+    if auth_user is None:
+        return False
+    with suppress(Exception):
+        return bool(
+            await check_access(
+                auth_user,
+                db,
+                project_id=project.id,
+                role=ProjectRole.PROJECT_ADMIN,
+            )
+        )
+    return False
+
+
 @get(
     path="/projects/{project_id:int}",
     dependencies={
@@ -260,6 +283,9 @@ async def project_details(
                 "form_templates_json": json.dumps(form_templates),
                 "can_delete_project": _can_delete_project(auth_user, project),
                 "show_qfc_collaborator_form": _show_qfc_collaborator_form(project),
+                "show_assignment_panel": await _show_assignment_panel(
+                    db, auth_user, project
+                ),
             },
         )
     except KeyError:
@@ -271,6 +297,7 @@ async def project_details(
                 "form_templates_json": "[]",
                 "can_delete_project": False,
                 "show_qfc_collaborator_form": False,
+                "show_assignment_panel": False,
             },
         )
 

--- a/src/backend/app/htmx/setup_steps/setup_step_map_layers.py
+++ b/src/backend/app/htmx/setup_steps/setup_step_map_layers.py
@@ -9,6 +9,7 @@ from litestar.response import Response, Template
 
 from app.htmx.map_helpers import render_leaflet_map
 from app.i18n import _
+from app.projects.project_services import count_assigned_tasks
 
 from ..htmx_helpers import callout as _callout
 
@@ -152,6 +153,11 @@ def build_split_preview_response(
             "split_preview_msg": split_preview_msg,
             "map_html_content": map_html_content,
             "tasks_geojson_str": tasks_geojson_str,
+            # Accepting the split overwrites the stored task areas; warn
+            # first when that would discard existing assignments.
+            "discard_assignment_count": count_assigned_tasks(
+                getattr(project, "task_areas_geojson", None)
+            ),
         },
         media_type="text/html",
         status_code=status.HTTP_200_OK,

--- a/src/backend/app/htmx/setup_steps/setup_step_parsing.py
+++ b/src/backend/app/htmx/setup_steps/setup_step_parsing.py
@@ -14,11 +14,13 @@ log = logging.getLogger(__name__)
 
 
 def parse_json_payload(
-    raw_value, invalid_message: str, log_prefix: str
+    raw_value, invalid_message: str, log_prefix: str, *, unescape: bool = True
 ) -> tuple[dict | None, Response | None]:
     try:
         normalized_value = (
-            html.unescape(raw_value) if isinstance(raw_value, str) else raw_value
+            html.unescape(raw_value)
+            if unescape and isinstance(raw_value, str)
+            else raw_value
         )
         return json.loads(normalized_value), None
     except (json.JSONDecodeError, TypeError) as e:

--- a/src/backend/app/locales/am/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/am/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: am\n"
@@ -159,31 +159,31 @@ msgstr "በከፍተኛ የግንኙነት ስህተት ምክንያት %(action
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API HTTP %(status_code)s ተመልሷል።"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "የ YAML ቅጽን ወደ XLSForm መቀየር አልተሳካም።"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "ትክክለኛ .xls ወይም .xlsx ፋይል ያቅርቡ"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "ትክክለኛ .xls ወይም .xlsx ፋይል ያቅርቡ"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "ትክክለኛ .xls ወይም .xlsx ፋይል ያቅርቡ"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "ወደ ጥሬ-ዳታ-ኤፒአይ መግባት አልተቻለም"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "ምንም ጂኦሜትሪዎች የሉም"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "የጂኦጅሰን ፋይልህ ልክ ያልሆነ ነው።"
 
@@ -254,50 +254,50 @@ msgstr "ወደ ማፕ አገልጋይ ሲገናኝ ማረጋገጫ አልተሳ�
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR ኮዱን ሲፈጥር ያልተጠበቀ ስህተት ተከስቷል።"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "ፕሮጀክት (%(project_id)s) አልተገኘም።"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "ይህን ፕሮጀክት ሊሰርዘው የሚችለው የፕሮጀክት አስተዳዳሪ ብቻ ነው።"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "ፕሮጀክቱ አልተገኘም።"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "ስህተት: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "የሚከተሉት ተጠቃሚ(ዎች) እንደ የፕሮጀክት አርታዒዎች ታክለዋል፡%(names)s።"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s': %(reason)s ማከል አልተቻለም"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "ተጨማሪ ተባባሪዎችን ያክሉ"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "የQFieldCloud ተባባሪዎችን ይጋብዙ"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
 msgstr "ለዚህ ፕሮጀክት መዳረሻ ከመስጠትዎ በፊት ካርታዎች በQFieldCloud ላይ መለያ ሊኖራቸው ይገባል።"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -307,7 +307,7 @@ msgstr ""
 "target=\"_blank\" rel=\"noopener\" class=\"ftm-link--"
 "brand\">app.qfield.cloud</a> ላይ እንዲፈጥር ያድርጉ።"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -316,23 +316,23 @@ msgstr ""
 "የQFieldCloud የተጠቃሚ ስሞቻቸውን ከታች አስገባ (ለበርካታ ተጠቃሚዎች በነጠላ ሰረዝ የተለየ) እና አስገባን "
 "ጠቅ አድርግ። እንደ አርታኢ ይታከላሉ እና ካርታ መስራት ለመጀመር ወደ QField መግባት ይችላሉ።"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "ለምሳሌ. አሊስ, ቦብ, ቻርሊ"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "ተባባሪዎችን ያክሉ"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "ቢያንስ አንድ የQFieldCloud የተጠቃሚ ስም ያስገቡ።"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "የQFieldCloud ፕሮጀክት መታወቂያ ለዚህ ፕሮጀክት አልተገኘም።"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -340,18 +340,42 @@ msgstr ""
 "ይህ ፕሮጀክት የተፈጠረው በብጁ QFieldCloud ምሳሌ ነው። ተባባሪዎችን ለማስተዳደር የQFieldCloud "
 "አስተዳደር ትርን ይጠቀሙ።"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON ወደ ውጭ መላክ የሚገኘው ለQField ፕሮጀክቶች ብቻ ነው።"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "ይህ ፕሮጀክት ገና ከQFieldCloud ፕሮጀክት ጋር አልተገናኘም።"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON ወደ ውጭ መላክ አልተሳካም: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "ፕሮጀክቱ አልተገኘም ወይም መዳረሻ ተከልክሏል።"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -391,11 +415,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "በዚህ ስርጭት ላይ የQField የመሠረት ካርታ ማያያዝ አልተዋቀረም። %(config)s ይጎድላል።"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "ፕሮጀክቱ አልተገኘም ወይም መዳረሻ ተከልክሏል።"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -699,7 +718,7 @@ msgid ""
 msgstr "ምንም GeoJSON ውሂብ አልተገኘም። እባክዎ መጀመሪያ የOSM ውሂብ ያውርዱ ወይም GeoJSON ፋይል ይስቀሉ።"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "የፕሮጀክት AOI"
 
@@ -766,25 +785,25 @@ msgstr ""
 "ODK URL፣ የተጠቃሚ ስም እና የይለፍ ቃል (ሶስቱንም) ያቅርቡ፣ ወይም የአገልጋዩን ነባሪዎች ለመጠቀም ሁሉንም "
 "ባዶ ይተዉ።"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "የውሂብ ማውጫ (%(data_feature_count)s ባህሪዎች)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "የተግባር ድንበሮች (%(task_count)s ተግባሮች)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "የተግባር መለያ"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "የህንፃ ብዛት"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -792,7 +811,7 @@ msgstr ""
 "ምንም የተግባር ድንበር አልተገኘም። እባክዎ መጀመሪያ ከላይ ያለውን \"Split AOI\" አዝራር በመጠቀም "
 "ፕሮጀክቱን ወደ ተግባሮች ይከፋፍሉ።"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -801,7 +820,7 @@ msgstr ""
 "✓ AOI በተሳካ ሁኔታ ተከፍሏል! %(algorithm)s በመጠቀም %(task_count)s የተግባር አካባቢዎች "
 "ተፈጥረዋል።"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -886,29 +905,29 @@ msgstr "የተግባር አካባቢዎች ውሂብ ቅርጸት ልክ አይ�
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ የተከፈሉ ተግባሮች በተሳካ ሁኔታ ተቀምጠዋል"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -917,7 +936,7 @@ msgstr ""
 "አካባቢው %(area_km2)s km² ነው፣ ይህም የ%(area_limit)s km² ገደብን ያልፋል። እባክዎ የፕሮጀክት"
 " አካባቢውን ያነሱ።"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -926,47 +945,47 @@ msgstr ""
 "አካባቢው %(area_km2)s km² ነው። ትላልቅ አካባቢዎች (>%(area_warn)s km²) ለማስኬድ ተጨማሪ ጊዜ"
 " ሊወስዱ ይችላሉ።"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON ያስፈልጋል"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "ምንም ፖሊጎን ጂኦሜትሪ አልተገኘም። የፕሮጀክት አካባቢ ፖሊጎን መሆን አለበት።"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "የተመረጠው ቦታ በጣም ትልቅ ነው። እባክዎ ከ200 km² ያነሰ ቦታ ይምረጡ።"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "ከጥሬ ውሂብ ኤፒአይ የውሂብ ማውጣትን ማመንጨት አልተሳካም።"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "ፕሮጀክቱ አልተገኘም።"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "ፕሮጀክቱ አልተገኘም።"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "ፕሮጀክቱ አልተገኘም።"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "ፕሮጀክቱ አልተገኘም።"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "የአብነት ቅጽ መጫን አልተሳካም።"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -974,25 +993,50 @@ msgstr ""
 "ይህ ፕሮጀክት በFieldTM ውስጥ በቀላሉ በሚሰራ ሂደት ተፈጥሯል እና OpenStreetMapን ለማሻሻል የህንፃ "
 "መረጃ ለመሰብሰብ የተዘጋጀ ነው።"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "ስም የሌለው አካባቢ"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "አካባቢ {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "የፕሮጀክት ዝርዝር ጠፍቷል ወይም ጂኦሜትሪ የለውም።"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "የፕሮጀክት ዝርዝር ጂኦሜትሪ ምንም መጋጠሚያዎች የሉትም።"
 
@@ -2074,8 +2118,8 @@ msgstr "አጥፋ"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "የቅጽ አማራጮች፡"
 
@@ -2097,7 +2141,7 @@ msgstr "ብጁ GeoJSON ስቀል"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ወይም"
 
@@ -2175,7 +2219,7 @@ msgid "Project Location"
 msgstr "የፕሮጀክት ቦታ"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "የዳሰሳ ቅጽ"
 
@@ -2208,39 +2252,39 @@ msgstr ""
 "ወደዚህ ፕሮጀክት ተጨማሪ የሚዲያ ፋይሎችን ለምሳሌ ምስሎችን እና ቪዲዮዎችን መስቀል ከፈለጉ፣ ወደ ODK Central"
 " ይግቡ እና በቅጽ ቅንብሮች ውስጥ ይስቀሉ።"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "ለካርታ ስራ ዝግጁ"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR ኮድ በመጫን ላይ..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "የተባባሪ ቅጽ በመጫን ላይ..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "የፕሮጀክት ቅንብር"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "የፕሮጀክት ቅንብር"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "የፕሮጀክት AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "ደረጃ 3፡ ውሂብ አግኝ"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI ከፋፍል"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "ፕሮጀክት ጨርስ"
 
@@ -2292,7 +2336,7 @@ msgstr "ፖሊላይኖች"
 msgid "points"
 msgstr "ነጥቦች"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "ባህሪዎች"
@@ -2323,7 +2367,7 @@ msgstr "የተመከረው ምንጭ ተዘምኗል (%(geom_label)s)። ውሂ�
 msgid "Downloading..."
 msgstr "በማውረድ ላይ..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "የOSM ውሂብ አውርድ"
@@ -2340,7 +2384,7 @@ msgstr "በካሬ ከፋፍል"
 msgid "Split by buildings"
 msgstr "በሕንጻዎች ከፋፍል"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "እንደገና ከፋፍል"
@@ -2432,6 +2476,129 @@ msgstr "ፕሮጀክት በ%(project_type)s ውስጥ በመፍጠር ላይ... 
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "ስህተት፡"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2619,7 +2786,14 @@ msgstr ""
 "የአስተዳዳሪ መለያው በራስ-ሰር መፈጠር አልቻለም። ፕሮጀክቱን ለማስተዳደር እንደ admin ወደ QFieldCloud "
 "ይግቡ።"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "የተግባር ምርጫዎችን ተቀበል"
 
@@ -2740,95 +2914,104 @@ msgstr ""
 "ለፕሮጀክትዎ አካባቢ ከOpenStreetMap ያሉ ነገሮችን ይውሰዱ፣ ወይም ማፕ አድራጊዎች ሁሉንም ከመጀመሪያ "
 "እንዲሰበስቡ ባዶ ካርታ ይጀምሩ።"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "ባዶ ካርታ ይጀምሩ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "ብጁ GeoJSON ስቀል"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "ለዚህ ፕሮጀክት የተመከሩ ነባሪዎች ንቁ ናቸው።"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "ምን ማውረድ እንዳለበት"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "የOSM ሕንጻዎች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "የOSM መንገዶች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "የOSM ጤና አገልግሎት"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "የOSM መጸዳጃ ቤቶች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "የOSM ሃይማኖታዊ ቦታዎች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "የOSM የመሬት አጠቃቀም"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "የOSM የውሃ መስመሮች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "የOSM የውሃ ነጥቦች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "የOSM ቆሻሻ ማስወገጃ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "የOSM ትምህርት"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "የOSM መቃብር ቦታዎች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "የOSM አገልግሎቶች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "ባህሪዎች"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "ፖሊጎን"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "ፖሊላይን"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "ነጥብ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "ማእከላዊ ነጥቦችን ተጠቀም (ለOSM ውሂብ ማውረድ)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "ፖሊጎኖችን ወደ ነጠላ ነጥቦች ይቀይሩ።"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "የOSM ውሂብ ማውጫ በመፍጠር ላይ... ይህ ትንሽ ጊዜ ሊወስድ ይችላል።"
 
@@ -2860,90 +3043,100 @@ msgstr ""
 "ብዙ ማፕ አድራጊዎች በተመሳሳይ ጊዜ እንዲሰሩ አካባቢዎን ወደ ትናንሽ ተግባሮች ይክፈሉ። ከታች እንዴት እንደሚከፈል "
 "ይምረጡ፣ ውጤቱን ይመልከቱ፣ ከዚያ ይቀበሉት። ወይም ሙሉ አካባቢውን እንደ አንድ ተግባር ለመጠቀም ይዝለሉ።"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "በመከፋፈል ላይ..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
 "          boundaries."
 msgstr "በሕንፃ ብዛት ሲከፈል፣ እነዚህ መስመራዊ ነገሮች እንደ ተፈጥሯዊ የተግባር ወሰኖች ይጠቀማሉ።"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "መንገዶችን አካትት"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "ወንዞችን አካትት"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "የባቡር መስመሮችን አካትት"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "የአየር መስመሮችን አካትት"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "እንዴት መክፈል እንደሚቻል"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "ዘዴ ይምረጡ..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "በሕንፃ ብዛት (ፈጣን)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "በሕንፃ ብዛት (ንጹህ ቅርጾች)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "በመደበኛ ግሪድ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "በተወሰነ የተግባር ብዛት ከፋፍል (በቅርብ ጊዜ)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "በአንድ ተግባር አማካይ ሕንጻዎች፡"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "የተግባሮች ብዛት፡"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "የግሪድ ካሬ መጠን (ሜትር)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "እንደገና ከፋፍል"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOIን ወደ ተግባሮች በመከፋፈል ላይ... ይህ ትንሽ ጊዜ ሊወስድ ይችላል።"
 

--- a/src/backend/app/locales/ar/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ar/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ar\n"
@@ -160,31 +160,31 @@ msgstr "فشل %(action)s بسبب خطأ في الاتصال المنبع."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "قامت واجهة برمجة تطبيقات Tilepack بإرجاع HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "فشل تحويل نموذج YAML إلى XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "يرجى تقديم ملف .xls أو .xlsx صالح"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "يرجى تقديم ملف .xls أو .xlsx صالح"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "يرجى تقديم ملف .xls أو .xlsx صالح"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "تعذر تسجيل الدخول إلى Raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "لا توجد أشكال هندسية موجودة"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "ملف Geojson الخاص بك غير صالح."
 
@@ -257,44 +257,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "حدث خطأ غير متوقع أثناء إنشاء رمز QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "لم يتم العثور على المشروع (%(project_id)s)."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "لا يمكن حذف هذا المشروع إلا من قبل مدير المشروع."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "لم يتم العثور على المشروع."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "خطأ: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "تمت إضافة المستخدم (المستخدمين) التاليين كمحرري المشروع: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "تعذرت إضافة '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "إضافة المزيد من المتعاونين"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "قم بدعوة المتعاونين مع QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -302,7 +302,7 @@ msgstr ""
 "يجب أن يكون لدى مصممي الخرائط حساب على QFieldCloud قبل أن تتمكن من منحهم "
 "حق الوصول إلى هذا المشروع."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -312,7 +312,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -322,23 +322,23 @@ msgstr ""
 "مستخدمين) وانقر فوق إرسال. ستتم إضافتهم كمحررين ويمكنهم تسجيل الدخول إلى "
 "QField لبدء رسم الخرائط."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "على سبيل المثال أليس، بوب، تشارلي"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "إضافة المتعاونين"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "أدخل اسم مستخدم QFieldCloud واحد على الأقل."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "لم يتم العثور على معرف مشروع QFieldCloud لهذا المشروع."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -346,18 +346,42 @@ msgstr ""
 "تم إنشاء هذا المشروع على نسخة QFieldCloud مخصصة. استخدم علامة التبويب "
 "QFieldCloud Admin لإدارة المتعاونين."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "تصدير GeoJSON متاح فقط لمشاريع QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "لم يتم ربط هذا المشروع بعد بمشروع QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "فشل تصدير GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "لم يتم العثور على المشروع أو تم رفض الوصول."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -401,11 +425,6 @@ msgid ""
 msgstr ""
 "إرفاق الخريطة الأساسية في QField غير مُعد في هذا النشر. العنصر المفقود هو"
 " %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "لم يتم العثور على المشروع أو تم رفض الوصول."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -713,7 +732,7 @@ msgstr ""
 "GeoJSON أولاً."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "منطقة اهتمام المشروع"
 
@@ -786,25 +805,25 @@ msgstr ""
 "قدّم رابط ODK واسم المستخدم وكلمة المرور (الثلاثة معًا)، أو اتركها كلها "
 "فارغة لاستخدام الإعدادات الافتراضية للخادم."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "استخراج البيانات (%(data_feature_count)s معالم)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "حدود المهام (%(task_count)s مهام)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "معرّف المهمة"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "عدد المباني"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -812,7 +831,7 @@ msgstr ""
 "لم يتم العثور على حدود للمهام. يرجى تقسيم المشروع إلى مهام أولاً باستخدام"
 " زر \"تقسيم AOI\" أعلاه."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -821,7 +840,7 @@ msgstr ""
 "✓ تم تقسيم AOI بنجاح! تم إنشاء %(task_count)s مناطق مهام باستخدام "
 "%(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -909,29 +928,29 @@ msgstr "تنسيق بيانات مناطق المهام غير صالح."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ تم حفظ المهام المقسمة بنجاح"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -940,7 +959,7 @@ msgstr ""
 "تبلغ المساحة %(area_km2)s كم²، وهذا يتجاوز حد %(area_limit)s كم². يُرجى "
 "تقليل مساحة المشروع."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -949,47 +968,47 @@ msgstr ""
 "تبلغ المساحة %(area_km2)s كم². قد تستغرق المساحات الكبيرة (>%(area_warn)s"
 " كم²) وقتًا أطول للمعالجة."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "ملف GeoJSON مطلوب"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "لم يتم العثور على أشكال مضلعة. يجب أن تكون منطقة المشروع مضلعًا."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "المنطقة المحددة كبيرة جدًا. يرجى تحديد منطقة أصغر من 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "فشل في إنشاء مستخلص البيانات من واجهة برمجة تطبيقات البيانات الأولية."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "لم يتم العثور على المشروع."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "لم يتم العثور على المشروع."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "لم يتم العثور على المشروع."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "لم يتم العثور على المشروع."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "فشل تحميل نموذج القالب."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -997,25 +1016,50 @@ msgstr ""
 "تم إنشاء هذا المشروع بسير عمل مبسط في FieldTM وهو مخصص لجمع بيانات "
 "المباني لتحسين OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "منطقة بدون اسم"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "المنطقة {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "مخطط المشروع مفقود أو ليس له أي شكل هندسي."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "هندسة المخطط التفصيلي للمشروع ليس لها إحداثيات."
 
@@ -2132,8 +2176,8 @@ msgstr "مسح"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "خيارات النموذج:"
 
@@ -2155,7 +2199,7 @@ msgstr "رفع GeoJSON مخصص"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "أو"
 
@@ -2235,7 +2279,7 @@ msgid "Project Location"
 msgstr "موقع المشروع"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "نموذج الاستبيان"
 
@@ -2268,39 +2312,39 @@ msgstr ""
 "إذا كنت بحاجة إلى رفع ملفات وسائط إضافية إلى هذا المشروع، مثل الصور "
 "ومقاطع الفيديو، فسجّل الدخول إلى ODK Central وارفعها من إعدادات النموذج."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "جاهز لرسم الخرائط"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "جارٍ تحميل رمز QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "جارٍ تحميل نموذج المتعاون..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "إعداد المشروع"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "إعداد المشروع"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "منطقة اهتمام المشروع"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "الخطوة 3: جلب البيانات"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "تقسيم AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "إنهاء المشروع"
 
@@ -2352,7 +2396,7 @@ msgstr "خطوط متعددة"
 msgid "points"
 msgstr "نقاط"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "معالم"
@@ -2387,7 +2431,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "جارٍ التنزيل..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "تنزيل بيانات OSM"
@@ -2404,7 +2448,7 @@ msgstr "التقسيم حسب المربع"
 msgid "Split by buildings"
 msgstr "التقسيم حسب المباني"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "إعادة التقسيم"
@@ -2496,6 +2540,129 @@ msgstr "جارٍ إنشاء المشروع في %(project_type)s... قد يست�
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "خطأ:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2688,7 +2855,14 @@ msgstr ""
 "تعذر إنشاء حساب المدير تلقائيًا. سجّل الدخول إلى QFieldCloud كمسؤول "
 "لإدارة المشروع."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "قبول خيارات المهام"
 
@@ -2811,95 +2985,104 @@ msgstr ""
 "استخرج المعالم الموجودة من OpenStreetMap لمنطقة مشروعك، أو ابدأ بخريطة "
 "فارغة حتى يجمع المساهمون كل شيء من الصفر."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "ابدأ بخريطة فارغة"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "رفع GeoJSON مخصص"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "الإعدادات الافتراضية الموصى بها مفعّلة لهذا المشروع."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "ما الذي سيتم تنزيله"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "مباني OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "طرق OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "رعاية صحية OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "دورات مياه OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "معالم دينية OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "استخدامات الأراضي OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "مجاري مائية OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "نقاط مياه OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "التخلص من النفايات OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "تعليم OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "مقابر OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "مرافق OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "معالم"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "مضلع"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "خط متعدد"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "نقطة"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "استخدم مراكز الأشكال (لتنزيل بيانات OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "حوّل المضلعات إلى نقاط منفردة."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "جارٍ إنشاء استخراج بيانات OSM... قد يستغرق ذلك بعض الوقت."
 
@@ -2932,11 +3115,21 @@ msgstr ""
 "طريقة التقسيم أدناه، وعاين النتيجة، ثم اقبلها. أو تخطَّ ذلك لاستخدام "
 "المنطقة كلها كمهمة واحدة."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "جارٍ التقسيم..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2945,79 +3138,79 @@ msgstr ""
 "عند التقسيم حسب عدد المباني، تُستخدم هذه المعالم الخطية كحدود طبيعية "
 "للمهام."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "تضمين الطرق"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "تضمين الأنهار"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "تضمين السكك الحديدية"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "تضمين المسارات الجوية"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "كيفية التقسيم"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "اختر طريقة..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "حسب عدد المباني (أسرع)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "حسب عدد المباني (أشكال أنظف)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "حسب شبكة منتظمة"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "التقسيم حسب عدد محدد من المهام (قريبًا)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "متوسط المباني لكل مهمة:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "عدد المهام:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "حجم مربع الشبكة (بالمتر)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "إعادة التقسيم"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "جارٍ تقسيم AOI إلى مهام... قد يستغرق ذلك بعض الوقت."
 

--- a/src/backend/app/locales/bn/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/bn/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: bn\n"
@@ -162,31 +162,31 @@ msgstr "আপস্ট্রিম সংযোগ ত্রুটির কা
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API HTTP %(status_code)s ফেরত দিয়েছে।"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML ফর্মকে XLSForm-এ রূপান্তর করতে ব্যর্থ হয়েছে৷"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "একটি বৈধ .xls বা .xlsx ফাইল প্রদান করুন"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "একটি বৈধ .xls বা .xlsx ফাইল প্রদান করুন"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "একটি বৈধ .xls বা .xlsx ফাইল প্রদান করুন"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-api-তে লগইন করা যায়নি"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "কোন জ্যামিতি উপস্থিত নেই"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "আপনার জিওজসন ফাইলটি অবৈধ।"
 
@@ -261,46 +261,46 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR কোড তৈরি করার সময় একটি অপ্রত্যাশিত ত্রুটি ঘটেছে।"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "প্রকল্প (%(project_id)s) পাওয়া যায়নি।"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "শুধুমাত্র প্রকল্প ব্যবস্থাপক এই প্রকল্প মুছে দিতে পারেন।"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "প্রকল্প পাওয়া যায়নি।"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "ত্রুটি: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 "প্রকল্প সম্পাদক হিসাবে নিম্নলিখিত ব্যবহারকারী(গুলি) যোগ করা হয়েছে: "
 "%(names)s৷"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' যোগ করা যায়নি: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "আরো সহযোগী যোগ করুন"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud সহযোগীদের আমন্ত্রণ জানান"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -308,7 +308,7 @@ msgstr ""
 "আপনি এই প্রকল্পে তাদের অ্যাক্সেস দেওয়ার আগে ম্যাপারদের অবশ্যই "
 "QFieldCloud-এ একটি অ্যাকাউন্ট থাকতে হবে।"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -318,7 +318,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> এ একটি "
 "বিনামূল্যে অ্যাকাউন্ট তৈরি করতে বলুন৷"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -328,23 +328,23 @@ msgstr ""
 "কমা দ্বারা পৃথক) এবং জমা দিন ক্লিক করুন৷ তারা সম্পাদক হিসাবে যুক্ত হবে "
 "এবং ম্যাপিং শুরু করতে QField-এ লগ ইন করতে পারবে।"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "যেমন এলিস, বব, চার্লি"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "সহযোগীদের যোগ করুন"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "অন্তত একটি QFieldCloud ব্যবহারকারীর নাম লিখুন।"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "এই প্রকল্পের জন্য QFieldCloud প্রকল্প আইডি পাওয়া যায়নি।"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -352,18 +352,42 @@ msgstr ""
 "এই প্রকল্পটি একটি কাস্টম QFieldCloud উদাহরণে তৈরি করা হয়েছিল। সহযোগীদের "
 "পরিচালনা করতে QFieldCloud অ্যাডমিন ট্যাব ব্যবহার করুন।"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON এক্সপোর্ট শুধুমাত্র QField প্রকল্পের জন্য উপলব্ধ।"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "এই প্রকল্পটি এখনও একটি QFieldCloud প্রকল্পের সাথে লিঙ্ক করা হয়নি৷"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON রপ্তানি করতে ব্যর্থ হয়েছে: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "প্রকল্প পাওয়া যায়নি অথবা প্রবেশাধিকার প্রত্যাখ্যাত।"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -410,11 +434,6 @@ msgid ""
 msgstr ""
 "এই ডিপ্লয়মেন্টে QField বেসম্যাপ সংযুক্তি কনফিগার করা নেই। %(config)s "
 "অনুপস্থিত।"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "প্রকল্প পাওয়া যায়নি অথবা প্রবেশাধিকার প্রত্যাখ্যাত।"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -725,7 +744,7 @@ msgstr ""
 "GeoJSON ফাইল আপলোড করুন।"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "প্রকল্প AOI"
 
@@ -798,25 +817,25 @@ msgstr ""
 "ODK URL, ব্যবহারকারীর নাম ও পাসওয়ার্ড (সব ৩টি) দিন, অথবা সার্ভারের "
 "ডিফল্ট ব্যবহার করতে সবগুলো ফাঁকা রাখুন।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "ডেটা এক্সট্র্যাক্ট (%(data_feature_count)s বৈশিষ্ট্য)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "কাজের সীমানা (%(task_count)s কাজ)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "টাস্ক আইডি"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "ভবনের সংখ্যা"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -824,7 +843,7 @@ msgstr ""
 "কোনো কাজের সীমানা পাওয়া যায়নি। আগে উপরের \"Split AOI\" বোতাম ব্যবহার "
 "করে প্রকল্পকে কাজগুলোতে ভাগ করুন।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -833,7 +852,7 @@ msgstr ""
 "✓ AOI সফলভাবে ভাগ করা হয়েছে! %(algorithm)s ব্যবহার করে %(task_count)s "
 "কাজের এলাকা তৈরি হয়েছে।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -924,29 +943,29 @@ msgstr "কাজের এলাকা ডেটার ফরম্যাট �
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ বিভক্ত কাজগুলো সফলভাবে সংরক্ষিত হয়েছে"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -955,7 +974,7 @@ msgstr ""
 "এলাকার আকার %(area_km2)s km², যা %(area_limit)s km² সীমা অতিক্রম করেছে। "
 "অনুগ্রহ করে প্রকল্পের এলাকা কমান।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -964,49 +983,49 @@ msgstr ""
 "এলাকার আকার %(area_km2)s km²। বড় এলাকা (>%(area_warn)s km²) প্রক্রিয়া "
 "করতে বেশি সময় লাগতে পারে।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON আবশ্যক"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "কোনো পলিগন জ্যামিতি পাওয়া যায়নি। প্রকল্পের এলাকা অবশ্যই পলিগন হতে হবে।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "নির্বাচিত এলাকা খুবই বড়। অনুগ্রহ করে 200 km² এর চেয়ে ছোট একটি এলাকা "
 "নির্বাচন করুন।"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "কাঁচা ডেটা API থেকে ডেটা নির্যাস তৈরি করতে ব্যর্থ হয়েছে৷"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "প্রকল্প পাওয়া যায়নি।"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "প্রকল্প পাওয়া যায়নি।"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "প্রকল্প পাওয়া যায়নি।"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "প্রকল্প পাওয়া যায়নি।"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "টেমপ্লেট ফর্ম লোড করা যায়নি।"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1014,25 +1033,50 @@ msgstr ""
 "এই প্রকল্পটি FieldTM-এর একটি সরলীকৃত ওয়ার্কফ্লো দিয়ে তৈরি করা হয়েছে "
 "এবং OpenStreetMap উন্নত করতে ভবনের তথ্য সংগ্রহের জন্য তৈরি করা হয়েছে।"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "নামহীন এলাকা"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "এলাকা {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "প্রকল্পের রূপরেখা অনুপস্থিত বা কোন জ্যামিতি নেই।"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "প্রকল্পের রূপরেখা জ্যামিতির কোন স্থানাঙ্ক নেই।"
 
@@ -2163,8 +2207,8 @@ msgstr "মুছুন"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "ফর্মের বিকল্পসমূহ:"
 
@@ -2186,7 +2230,7 @@ msgstr "কাস্টম GeoJSON আপলোড করুন"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "অথবা"
 
@@ -2272,7 +2316,7 @@ msgid "Project Location"
 msgstr "প্রকল্পের অবস্থান"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "জরিপ ফর্ম"
 
@@ -2305,39 +2349,39 @@ msgstr ""
 "যদি এই প্রকল্পে অতিরিক্ত মিডিয়া ফাইল, যেমন ছবি বা ভিডিও, আপলোড করতে হয়,"
 " তবে ODK Central-এ লগইন করে ফর্ম সেটিংস থেকে আপলোড করুন।"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "মানচিত্রায়নের জন্য প্রস্তুত"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR কোড লোড হচ্ছে..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "সহযোগী ফর্ম লোড হচ্ছে..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "প্রকল্প সেটআপ"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "প্রকল্প সেটআপ"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "প্রকল্প AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "ধাপ ৩: ডেটা নিন"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI ভাগ করুন"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "প্রকল্প চূড়ান্ত করুন"
 
@@ -2391,7 +2435,7 @@ msgstr "পলিলাইন"
 msgid "points"
 msgstr "বিন্দু"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "বৈশিষ্ট্য"
@@ -2427,7 +2471,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "ডাউনলোড হচ্ছে..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM ডেটা ডাউনলোড করুন"
@@ -2444,7 +2488,7 @@ msgstr "বর্গাকারভাবে ভাগ করুন"
 msgid "Split by buildings"
 msgstr "ভবন অনুযায়ী ভাগ করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "আবার ভাগ করুন"
@@ -2536,6 +2580,129 @@ msgstr "%(project_type)s-এ প্রকল্প তৈরি হচ্ছে.
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "ত্রুটি:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2729,7 +2896,14 @@ msgstr ""
 "ব্যবস্থাপকের অ্যাকাউন্ট স্বয়ংক্রিয়ভাবে তৈরি করা যায়নি। প্রকল্প "
 "পরিচালনা করতে প্রশাসক হিসেবে QFieldCloud-এ লগইন করুন।"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "কাজের পছন্দ গ্রহণ করুন"
 
@@ -2858,95 +3032,104 @@ msgstr ""
 "অথবা খালি মানচিত্র দিয়ে শুরু করুন যাতে ম্যাপাররা শুরু থেকে সব সংগ্রহ "
 "করতে পারেন।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "খালি মানচিত্র দিয়ে শুরু করুন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "কাস্টম GeoJSON আপলোড করুন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "এই প্রকল্পের জন্য প্রস্তাবিত ডিফল্ট সক্রিয় রয়েছে।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "কী ডাউনলোড করবেন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM ভবন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM সড়ক"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM স্বাস্থ্যসেবা"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM টয়লেট"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM ধর্মীয় স্থান"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM ভূমি ব্যবহার"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM জলপথ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM পানির পয়েন্ট"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM বর্জ্য নিষ্পত্তি"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM শিক্ষা"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM কবরস্থান"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM সুবিধাসমূহ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "বৈশিষ্ট্য"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "পলিগন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "পলিলাইন"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "বিন্দু"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "সেন্ট্রয়েড ব্যবহার করুন (OSM ডেটা ডাউনলোডের জন্য)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "পলিগনকে একক পয়েন্টে রূপান্তর করুন।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM ডেটা এক্সট্র্যাক্ট তৈরি হচ্ছে... কিছু সময় লাগতে পারে।"
 
@@ -2979,11 +3162,21 @@ msgstr ""
 " নিচে কীভাবে ভাগ করবেন বেছে নিন, ফলাফল দেখুন, তারপর গ্রহণ করুন। অথবা পুরো"
 " এলাকা একটি কাজ হিসেবে ব্যবহার করতে এড়িয়ে যান।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "বিভাগ করা হচ্ছে..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2992,79 +3185,79 @@ msgstr ""
 "ভবনের সংখ্যা অনুযায়ী ভাগ করার সময়, এই রেখাচিত্র ফিচারগুলো প্রাকৃতিক "
 "কাজের সীমানা হিসেবে ব্যবহৃত হয়।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "রাস্তা অন্তর্ভুক্ত করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "নদী অন্তর্ভুক্ত করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "রেলপথ অন্তর্ভুক্ত করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "বিমানপথ অন্তর্ভুক্ত করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "কীভাবে ভাগ করবেন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "একটি পদ্ধতি বেছে নিন..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "ভবনের সংখ্যা অনুযায়ী (দ্রুত)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "ভবনের সংখ্যা অনুযায়ী (পরিষ্কার আকৃতি)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "নিয়মিত গ্রিড অনুযায়ী"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "নির্দিষ্ট সংখ্যক কাজে ভাগ করুন (শীঘ্রই আসছে)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "প্রতি কাজে গড় ভবন:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "কাজের সংখ্যা:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "গ্রিড ঘরের আকার (মিটার)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "আবার ভাগ করুন"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI-কে কাজে ভাগ করা হচ্ছে... কিছু সময় লাগতে পারে।"
 

--- a/src/backend/app/locales/cs/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/cs/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: cs\n"
@@ -161,31 +161,31 @@ msgstr "%(action)s se nezdařilo kvůli chybě připojení proti proudu. Rozhran
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack vrátilo HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Převedení formuláře YAML na XLSForm se nezdařilo."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Zadejte platný soubor .xls nebo .xlsx"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Zadejte platný soubor .xls nebo .xlsx"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Zadejte platný soubor .xls nebo .xlsx"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Nelze se přihlásit k raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Nejsou k dispozici žádné geometrie"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Váš soubor geojson je neplatný."
 
@@ -260,44 +260,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Při generování QR kódu došlo k neočekávané chybě."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Projekt (%(project_id)s) nebyl nalezen."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Tento projekt může smazat pouze správce projektu."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Projekt nebyl nalezen."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Chyba: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Jako editory projektu byli přidáni následující uživatelé: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Nelze přidat „%(username)s“: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Přidejte další spolupracovníky"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Pozvěte spolupracovníky QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -305,7 +305,7 @@ msgstr ""
 "Mapři musí mít účet na QFieldCloud, než jim udělíte přístup k tomuto "
 "projektu."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -315,7 +315,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -325,23 +325,23 @@ msgstr ""
 "více uživatelů) a klikněte na Odeslat. Budou přidáni jako editoři a mohou"
 " se přihlásit do QField a začít mapovat."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "např. Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Přidejte spolupracovníky"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Zadejte alespoň jedno uživatelské jméno QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID projektu QFieldCloud pro tento projekt nebylo nalezeno."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -349,18 +349,42 @@ msgstr ""
 "Tento projekt byl vytvořen na vlastní instanci QFieldCloud. Ke správě "
 "spolupracovníků použijte kartu Správce QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Export GeoJSON je k dispozici pouze pro projekty QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Tento projekt zatím není propojen s projektem QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Nepodařilo se exportovat GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Projekt nebyl nalezen nebo byl přístup odepřen."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -408,11 +432,6 @@ msgid ""
 msgstr ""
 "Připojení podkladové mapy QField není v tomto nasazení nakonfigurováno. "
 "Chybí %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Projekt nebyl nalezen nebo byl přístup odepřen."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -727,7 +746,7 @@ msgstr ""
 "nahrajte soubor GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI projektu"
 
@@ -800,25 +819,25 @@ msgstr ""
 "Zadejte URL ODK, uživatelské jméno a heslo (všechny 3), nebo je všechny "
 "ponechte prázdné pro použití výchozího nastavení serveru."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Datový výřez (%(data_feature_count)s prvků)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Hranice úkolů (%(task_count)s úkolů)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID úkolu"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Počet budov"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -826,7 +845,7 @@ msgstr ""
 "Nebyly nalezeny žádné hranice úkolů. Nejprve rozdělte projekt na úkoly "
 "pomocí tlačítka „Rozdělit AOI“ výše."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -835,7 +854,7 @@ msgstr ""
 "✓ AOI byla úspěšně rozdělena! Pomocí %(algorithm)s bylo vytvořeno "
 "%(task_count)s oblastí úkolů."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -926,29 +945,29 @@ msgstr "Neplatný formát dat oblastí úkolů."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Rozdělené úkoly byly úspěšně uloženy"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -957,7 +976,7 @@ msgstr ""
 "Oblast má %(area_km2)s km², což překračuje limit %(area_limit)s km². "
 "Zmenšete prosím oblast projektu."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -966,51 +985,51 @@ msgstr ""
 "Oblast má %(area_km2)s km². Velké oblasti (>%(area_warn)s km²) mohou "
 "zpracování trvat déle."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON je povinné"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Nebyly nalezeny žádné polygonové geometrie. Oblast projektu musí být "
 "polygon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Vybraná oblast je příliš velká. Vyberte prosím oblast menší než 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr ""
 "Vygenerování extraktu dat z rozhraní API nezpracovaných dat se nezdařilo."
 " Šablona"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Projekt nebyl nalezen."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Projekt nebyl nalezen."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Projekt nebyl nalezen."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Projekt nebyl nalezen."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Nepodařilo se načíst šablonu formuláře."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1018,25 +1037,50 @@ msgstr ""
 "Tento projekt byl vytvořen pomocí zjednodušeného postupu ve FieldTM a "
 "slouží ke sběru dat o budovách pro zlepšení OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Nepojmenovaná oblast"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Oblast {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Osnova projektu chybí nebo nemá geometrii."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr ""
 "Geometrie obrysu projektu nemá žádné souřadnice. Pro vytvoření projektu "
@@ -2170,8 +2214,8 @@ msgstr "Vymazat"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Možnosti formuláře:"
 
@@ -2193,7 +2237,7 @@ msgstr "Nahrát vlastní GeoJSON"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "nebo"
 
@@ -2277,7 +2321,7 @@ msgid "Project Location"
 msgstr "Poloha projektu"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Dotazníkový formulář"
 
@@ -2311,39 +2355,39 @@ msgstr ""
 "jsou obrázky a videa, přihlaste se do ODK Central a nahrajte je v "
 "nastavení formuláře."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Připraveno k mapování"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Načítání QR kódu..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Načítání formuláře spolupracovníka..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Nastavení projektu"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Nastavení projektu"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI projektu"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Krok 3: Získat data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Rozdělit AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Dokončit projekt"
 
@@ -2397,7 +2441,7 @@ msgstr "polylinie"
 msgid "points"
 msgstr "body"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "prvky"
@@ -2433,7 +2477,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Stahování..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Stáhnout data OSM"
@@ -2450,7 +2494,7 @@ msgstr "Rozdělit podle čtverce"
 msgid "Split by buildings"
 msgstr "Rozdělit podle budov"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Rozdělit znovu"
@@ -2544,6 +2588,129 @@ msgstr "Vytváření projektu v %(project_type)s... To může chvíli trvat."
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Chyba:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2741,7 +2908,14 @@ msgstr ""
 "Účet manažera nebylo možné vytvořit automaticky. Přihlaste se do "
 "QFieldCloud jako správce a projekt spravujte ručně."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Přijmout volby úkolů"
 
@@ -2869,95 +3043,104 @@ msgstr ""
 "Načtěte existující prvky z OpenStreetMap pro oblast projektu, nebo "
 "začněte s prázdnou mapou, aby mapéři mohli vše sbírat od začátku."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Začít s prázdnou mapou"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Nahrát vlastní GeoJSON"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Pro tento projekt jsou aktivní doporučená výchozí nastavení."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Co stáhnout"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Budovy OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Silnice OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Zdravotnictví OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Toalety OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Náboženské objekty OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Využití území OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Vodní toky OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Vodní body OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Likvidace odpadu OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Vzdělávání OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Hřbitovy OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Vybavenost OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "prvky"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Mnohoúhelník"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polylinie"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Bod"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Použít centroidy (Pro stažení dat OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Převést polygony na jednotlivé body."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Generování datového výřezu OSM... To může chvíli trvat."
 
@@ -2990,11 +3173,21 @@ msgstr ""
 " Níže vyberte způsob rozdělení, zobrazte náhled výsledku a přijměte ho. "
 "Nebo krok přeskočte a použijte celou oblast jako jeden úkol."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Rozdělování..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3003,79 +3196,79 @@ msgstr ""
 "Při dělení podle počtu budov se tyto liniové prvky používají jako "
 "přirozené hranice úkolů."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Zahrnout silnice"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Zahrnout řeky"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Zahrnout železnice"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Zahrnout letecké cesty"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Jak rozdělit"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Vyberte metodu..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Podle počtu budov (rychlejší)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Podle počtu budov (čistší tvary)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Podle pravidelné mřížky"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Rozdělit podle konkrétního počtu úkolů (již brzy)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Prům. budov na úkol:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Počet úloh:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Velikost čtverce mřížky (metry)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Rozdělit znovu"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Rozdělování AOI na úkoly... To může chvíli trvat."
 

--- a/src/backend/app/locales/es/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/es/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s falló debido a un error de conexión ascendente. La API"
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack devolvió HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "No se pudo convertir el formulario YAML a XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Proporcione un archivo .xls o .xlsx válido"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Proporcione un archivo .xls o .xlsx válido"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Proporcione un archivo .xls o .xlsx válido"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "No se pudo iniciar sesión en raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "No hay geometrías presentes"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Su archivo geojson no es válido."
 
@@ -261,46 +261,46 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Ocurrió un error inesperado al generar el código QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Proyecto (%(project_id)s) no encontrado."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Solo el gestor del proyecto puede eliminar este proyecto."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Proyecto no encontrado."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Error encontrado: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 "Se agregaron los siguientes usuarios como editores del proyecto: "
 "%(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "No se pudo agregar '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Añadir más colaboradores"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Invitar a colaboradores de QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -308,7 +308,7 @@ msgstr ""
 "Los mapeadores deben tener una cuenta en QFieldCloud antes de poder "
 "darles acceso a este proyecto."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -318,7 +318,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -328,23 +328,23 @@ msgstr ""
 "por comas para varios usuarios) y haga clic en enviar. Se agregarán como "
 "editores y podrán iniciar sesión en QField para comenzar a mapear."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "p.ej. alicia, bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Agregar colaboradores"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Ingrese al menos un nombre de usuario de QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "No se encontró el ID del proyecto QFieldCloud para este proyecto."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -353,18 +353,42 @@ msgstr ""
 "Utilice la pestaña Administrador de QFieldCloud para administrar "
 "colaboradores."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "La exportación GeoJSON solo está disponible para proyectos QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Este proyecto aún no está vinculado a un proyecto QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "No se pudo exportar GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Proyecto no encontrado o acceso denegado."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -411,11 +435,6 @@ msgid ""
 msgstr ""
 "La adjunción del mapa base de QField no está configurada en este "
 "despliegue. Falta %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Proyecto no encontrado o acceso denegado."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -738,7 +757,7 @@ msgstr ""
 "archivo GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Área de interés del proyecto"
 
@@ -814,25 +833,25 @@ msgstr ""
 "déjelos todos en blanco para usar los valores predeterminados del "
 "servidor."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Extracción de datos (%(data_feature_count)s elementos)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Límites de tareas (%(task_count)s tareas)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID de tarea"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Cantidad de edificios"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -840,7 +859,7 @@ msgstr ""
 "No se encontraron límites de tareas. Primero divida el proyecto en tareas"
 " usando el botón \"Dividir área de interés\" de arriba."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -849,7 +868,7 @@ msgstr ""
 "✓ ¡Área de interés dividida exitosamente! Se generaron %(task_count)s "
 "áreas de tareas usando %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -945,29 +964,29 @@ msgstr "Formato de datos de áreas de tareas inválido."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Tareas divididas guardadas exitosamente"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -976,7 +995,7 @@ msgstr ""
 "El área es de %(area_km2)s km², lo que supera el límite de %(area_limit)s"
 " km². Reduce el área del proyecto."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -985,51 +1004,51 @@ msgstr ""
 "El área es de %(area_km2)s km². Las áreas grandes (>%(area_warn)s km²) "
 "pueden tardar más en procesarse."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Se requiere GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "No se encontraron geometrías de polígono. El área del proyecto debe ser "
 "un polígono."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "El área seleccionada es demasiado grande. Seleccione un área menor a 200 "
 "km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "No se pudo generar el extracto de datos de la API de datos sin procesar."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Proyecto no encontrado."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Proyecto no encontrado."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Proyecto no encontrado."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Proyecto no encontrado."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Error al cargar el formulario de plantilla."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1038,25 +1057,50 @@ msgstr ""
 "está pensado para recopilar datos de edificios para mejorar "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Área sin nombre"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Área {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Falta el esquema del proyecto o no tiene geometría."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "La geometría del contorno del proyecto no tiene coordenadas."
 
@@ -2213,8 +2257,8 @@ msgstr "Limpiar"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Opciones del formulario:"
 
@@ -2236,7 +2280,7 @@ msgstr "Subir GeoJSON personalizado"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "o"
 
@@ -2323,7 +2367,7 @@ msgid "Project Location"
 msgstr "Ubicación del proyecto"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Formulario de encuesta"
 
@@ -2357,39 +2401,39 @@ msgstr ""
 "imágenes y videos, inicie sesión en ODK Central y súbalos en la "
 "configuración del formulario."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Listo para mapear"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Cargando código QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Cargando formulario de colaborador..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Configuración del proyecto"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Configuración del proyecto"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Área de interés del proyecto"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Paso 3: Obtener datos"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Dividir área de interés"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finalizar proyecto"
 
@@ -2447,7 +2491,7 @@ msgstr "polilíneas"
 msgid "points"
 msgstr "puntos"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "elementos"
@@ -2483,7 +2527,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Descargando..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Descargar datos OSM"
@@ -2500,7 +2544,7 @@ msgstr "Dividir por cuadrado"
 msgid "Split by buildings"
 msgstr "Dividir por edificios"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Dividir de nuevo"
@@ -2595,6 +2639,129 @@ msgstr "Creando proyecto en %(project_type)s... Esto puede tardar un momento."
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Mensaje de error:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2790,7 +2957,14 @@ msgstr ""
 "La cuenta del gestor no pudo crearse automáticamente. Inicie sesión en "
 "QFieldCloud como administrador para gestionar el proyecto."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Aceptar elecciones de tareas"
 
@@ -2919,95 +3093,104 @@ msgstr ""
 " o empieza con un mapa vacío para que los mapeadores recopilen todo desde"
 " cero."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Empezar con un mapa vacío"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Subir GeoJSON personalizado"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Los valores predeterminados recomendados están activos para este proyecto."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Qué descargar"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Edificios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Carreteras OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Salud OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Baños OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Lugares religiosos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Uso de suelo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Vías fluviales OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Puntos de agua OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Eliminación de residuos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Educación OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Cementerios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Equipamientos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "elementos"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Polígono"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilínea"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Punto"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Usar centroides (Para descarga de datos OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Convertir polígonos en puntos individuales."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Generando extracción de datos OSM... Esto puede tardar un momento."
 
@@ -3041,11 +3224,21 @@ msgstr ""
 "resultado y acéptalo. O salta este paso para usar toda el área como una "
 "sola tarea."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Dividiendo..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3054,79 +3247,79 @@ msgstr ""
 "Al dividir por número de edificios, estos elementos lineales se usan como"
 " límites naturales de las tareas."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Incluir caminos"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Incluir ríos"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Incluir ferrocarriles"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Incluir vías aéreas"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Cómo dividir"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Elige un método..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Por número de edificios (más rápido)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Por número de edificios (formas más limpias)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Por una cuadrícula regular"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Dividir por número específico de tareas (próximamente)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Edificios prom. por tarea:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Número de tareas:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Tamaño del cuadrado de la cuadrícula (metros)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Dividir de nuevo"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Dividiendo área de interés en tareas... Esto puede tardar un momento."
 

--- a/src/backend/app/locales/field_tm.pot
+++ b/src/backend/app/locales/field_tm.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -156,31 +156,31 @@ msgstr ""
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr ""
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr ""
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr ""
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr ""
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr ""
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr ""
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr ""
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr ""
 
@@ -251,96 +251,120 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
 "QField to start mapping."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr ""
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
 msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
@@ -378,11 +402,6 @@ msgstr ""
 msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
-msgstr ""
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
 msgstr ""
 
 #: app/htmx/basemap/basemap_fragments.py:105
@@ -680,7 +699,7 @@ msgid ""
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr ""
 
@@ -743,38 +762,38 @@ msgid ""
 "to use server defaults."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
 "%(algorithm)s."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -850,107 +869,132 @@ msgstr ""
 msgid "✓ Split tasks saved successfully"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
 "Please reduce your project area."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
 "longer to process."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr ""
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr ""
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr ""
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr ""
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr ""
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr ""
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
 msgstr ""
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr ""
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr ""
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr ""
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr ""
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr ""
 
@@ -1991,8 +2035,8 @@ msgstr ""
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr ""
 
@@ -2014,7 +2058,7 @@ msgstr ""
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr ""
 
@@ -2090,7 +2134,7 @@ msgid "Project Location"
 msgstr ""
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr ""
 
@@ -2121,39 +2165,39 @@ msgid ""
 "settings."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr ""
 
@@ -2205,7 +2249,7 @@ msgstr ""
 msgid "points"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr ""
@@ -2234,7 +2278,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr ""
@@ -2251,7 +2295,7 @@ msgstr ""
 msgid "Split by buildings"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr ""
@@ -2340,6 +2384,129 @@ msgstr ""
 
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
 msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
@@ -2518,7 +2685,14 @@ msgid ""
 "      manage the project."
 msgstr ""
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr ""
 
@@ -2634,95 +2808,104 @@ msgid ""
 "    map so mappers can collect everything from scratch."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr ""
 
@@ -2752,90 +2935,100 @@ msgid ""
 "whole area as one task."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
 "          boundaries."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr ""
 

--- a/src/backend/app/locales/fr/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/fr/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:56+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -166,31 +166,31 @@ msgstr "%(action)s a échoué en raison d'une erreur de connexion en amont."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack a renvoyé HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Échec de la conversion du formulaire YAML en XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Fournissez un fichier .xls ou .xlsx valide"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Fournissez un fichier .xls ou .xlsx valide"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Fournissez un fichier .xls ou .xlsx valide"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Impossible de se connecter à l'api de données brutes"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Aucune géométrie présente"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Votre fichier geojson n'est pas valide."
 
@@ -267,46 +267,46 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Une erreur inattendue s'est produite lors de la génération du code QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Projet (%(project_id)s) introuvable."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Seul le gestionnaire de projet peut supprimer ce projet."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Projet introuvable."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Erreur : %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 "Ajout du ou des utilisateurs suivants en tant qu'éditeurs de projet : "
 "%(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Impossible d'ajouter « %(username)s » : %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Ajouter plus de collaborateurs"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Inviter des collaborateurs QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -314,7 +314,7 @@ msgstr ""
 "Les mappeurs doivent disposer d'un compte sur QFieldCloud avant que vous "
 "puissiez leur donner accès à ce projet."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -324,7 +324,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -335,23 +335,23 @@ msgstr ""
 "seront ajoutés en tant qu'éditeurs et pourront se connecter à QField pour"
 " démarrer le mappage."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "par ex. Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Ajouter des collaborateurs"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Entrez au moins un nom d'utilisateur QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID de projet QFieldCloud introuvable pour ce projet."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -359,18 +359,42 @@ msgstr ""
 "Ce projet a été créé sur une instance QFieldCloud personnalisée. Utilisez"
 " l'onglet Admin QFieldCloud pour gérer les collaborateurs."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "L'exportation GeoJSON est uniquement disponible pour les projets QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Ce projet n'est pas encore lié à un projet QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Échec de l'exportation de GeoJSON : %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Projet introuvable ou accès refusé."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -421,11 +445,6 @@ msgid ""
 msgstr ""
 "L’ajout du fond de carte QField n’est pas configuré sur ce déploiement. "
 "%(config)s est manquant."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Projet introuvable ou accès refusé."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -745,7 +764,7 @@ msgstr ""
 "OSM ou téléverser un fichier GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Zone d'intérêt du projet"
 
@@ -823,25 +842,25 @@ msgstr ""
 " laissez-les tous vides pour utiliser les paramètres par défaut du "
 "serveur."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Extraction de données (%(data_feature_count)s éléments)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Limites des tâches (%(task_count)s tâches)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID de la tâche"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Nombre de bâtiments"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -849,7 +868,7 @@ msgstr ""
 "Aucune limite de tâche trouvée. Veuillez d'abord diviser le projet en "
 "tâches en utilisant le bouton « Diviser la zone d'intérêt » ci-dessus."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -858,7 +877,7 @@ msgstr ""
 "✓ Zone d'intérêt divisée avec succès ! %(task_count)s zones de tâches "
 "générées avec %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -952,29 +971,29 @@ msgstr "Format de données des zones de tâches invalide."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Tâches divisées enregistrées avec succès"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -983,7 +1002,7 @@ msgstr ""
 "La zone fait %(area_km2)s km², ce qui dépasse la limite de %(area_limit)s"
 " km². Veuillez réduire la zone du projet."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -992,53 +1011,53 @@ msgstr ""
 "La zone fait %(area_km2)s km². Les grandes zones (>%(area_warn)s km²) "
 "peuvent prendre plus de temps à traiter."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Le GeoJSON est requis"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Aucune géométrie polygonale trouvée. La zone du projet doit être un "
 "polygone."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "La zone sélectionnée est trop grande. Veuillez sélectionner une zone "
 "inférieure à 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr ""
 "Échec de la génération de l'extrait de données à partir de l'API de "
 "données brutes."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Projet introuvable."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Projet introuvable."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Projet introuvable."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Projet introuvable."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Échec du chargement du formulaire modèle."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1046,25 +1065,50 @@ msgstr ""
 "Ce projet a été créé avec un flux simplifié dans FieldTM et sert à "
 "collecter des données sur les bâtiments afin d’améliorer OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Zone sans nom"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Zone {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Le contour du projet est manquant ou n'a pas de géométrie."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "La géométrie du contour du projet n'a pas de coordonnées."
 
@@ -2236,8 +2280,8 @@ msgstr "Effacer"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Options du formulaire :"
 
@@ -2259,7 +2303,7 @@ msgstr "Téléverser un GeoJSON personnalisé"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ou"
 
@@ -2348,7 +2392,7 @@ msgid "Project Location"
 msgstr "Emplacement du projet"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Formulaire d’enquête"
 
@@ -2382,39 +2426,39 @@ msgstr ""
 " projet, comme des images et des vidéos, connectez-vous à ODK Central et "
 "téléversez-les dans les paramètres du formulaire."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Prêt pour la cartographie"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Chargement du code QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Chargement du formulaire collaborateur..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Configuration du projet"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Configuration du projet"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Zone d'intérêt du projet"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Étape 3 : Obtenir les données"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Diviser la zone d'intérêt"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finaliser le projet"
 
@@ -2472,7 +2516,7 @@ msgstr "polylignes"
 msgid "points"
 msgstr "points géographiques"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "éléments"
@@ -2508,7 +2552,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Téléchargement en cours..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Télécharger les données OSM"
@@ -2525,7 +2569,7 @@ msgstr "Diviser par carré"
 msgid "Split by buildings"
 msgstr "Diviser par bâtiments"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Diviser à nouveau"
@@ -2620,6 +2664,129 @@ msgstr "Création du projet dans %(project_type)s... Cela peut prendre un moment
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Erreur :"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2817,7 +2984,14 @@ msgstr ""
 "Le compte gestionnaire n'a pas pu être créé automatiquement. Connectez-"
 "vous à QFieldCloud en tant qu'administrateur pour gérer le projet."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Accepter les choix de tâches"
 
@@ -2948,95 +3122,104 @@ msgstr ""
 "projet, ou commencer avec une carte vide afin que les cartographes "
 "collectent tout depuis le début."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Commencer avec une carte vide"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Téléverser un GeoJSON personnalisé"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Les paramètres par défaut recommandés sont actifs pour ce projet."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Que télécharger"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Bâtiments OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Routes OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Santé OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Toilettes OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Lieux religieux OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Occupation du sol OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Cours d'eau OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Points d'eau OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Élimination des déchets OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Éducation OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Cimetières OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Équipements OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "éléments"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Polygone"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polyligne"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Point géographique"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Utiliser les centroïdes (Pour le téléchargement des données OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Convertir les polygones en points uniques."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Génération de l'extraction de données OSM... Cela peut prendre un moment."
 
@@ -3070,11 +3253,21 @@ msgstr ""
 "dessous, prévisualisez le résultat, puis acceptez-le. Vous pouvez aussi "
 "ignorer cette étape pour utiliser toute la zone comme une seule tâche."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Division en cours..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3083,79 +3276,79 @@ msgstr ""
 "Lors d’une division par nombre de bâtiments, ces éléments linéaires sont "
 "utilisés comme limites naturelles des tâches."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Inclure les routes"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Inclure les rivières"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Inclure les voies ferrées"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Inclure les voies aériennes"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Méthode de division"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Choisissez une méthode..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Par nombre de bâtiments (plus rapide)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Par nombre de bâtiments (formes plus nettes)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Par grille régulière"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Diviser par nombre spécifique de tâches (bientôt disponible)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Bâtiments moy. par tâche :"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Nombre de tâches :"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Taille du carré de la grille (mètres)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Diviser à nouveau"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Division de la zone d'intérêt en tâches... Cela peut prendre un moment."
 

--- a/src/backend/app/locales/ha/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ha/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ha\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s ya gaza saboda kuskuren haɗin kai."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "ya dawo da HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "ya kasa canza tsarin YAML zuwa XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Bayar da ingantaccen fayil .xls ko .xlsx"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Bayar da ingantaccen fayil .xls ko .xlsx"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Bayar da ingantaccen fayil .xls ko .xlsx"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "ya kasa shiga raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Babu geometries ba"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Fayil ɗin ku na geojson ba shi da inganci."
 
@@ -258,44 +258,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "An samu kuskuren da ba a zata ba yayin ƙirƙirar lambar QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Ba a samu aikin (%(project_id)s) ba."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Mai kula da aikin kaɗai zai iya share wannan aikin."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Ba a samu aikin ba."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Kuskure: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "An ƙara masu amfani (masu) masu zuwa azaman masu gyara aikin: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Ba za a iya ƙara '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Ƙara ƙarin masu haɗin gwiwa"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Gayyatar masu haɗin gwiwar QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -303,7 +303,7 @@ msgstr ""
 "Dole ne masu taswirar su sami asusu akan QFieldCloud kafin ku iya ba su "
 "damar shiga wannan aikin."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -313,7 +313,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -323,23 +323,23 @@ msgstr ""
 "masu amfani da yawa) kuma danna ƙaddamarwa. Za a ƙara su azaman masu "
 "gyara kuma za su iya shiga QField don fara taswira."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "misali Alice, Bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Ƙara masu haɗin gwiwa"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Shigar da aƙalla sunan mai amfani QFieldCloud ɗaya."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "QFieldCloud ba a samo ID na aikin wannan aikin ba."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -347,18 +347,42 @@ msgstr ""
 "An ƙirƙiri wannan aikin akan misalin QFieldCloud na al'ada. Yi amfani da "
 "shafin Admin QFieldCloud don sarrafa masu haɗin gwiwa."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Ana samun fitarwar GeoJSON don ayyukan QField kawai."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Har yanzu ba a haɗa wannan aikin da aikin QFieldCloud ba."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "An kasa fitarwa GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Ba a samu aikin ba ko an hana shiga."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -404,11 +428,6 @@ msgid ""
 msgstr ""
 "Ba a saita haɗa taswirar tushe ta QField a wannan shimfiɗawa ba. "
 "%(config)s ya ɓace."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Ba a samu aikin ba ko an hana shiga."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -723,7 +742,7 @@ msgstr ""
 " fayil GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI na aikin"
 
@@ -796,25 +815,25 @@ msgstr ""
 "Bayar da ODK URL, sunan mai amfani, da kalmar sirri (duk uku), ko kuma a "
 "bar su a fanko don amfani da tsoffin saitunan sabar."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Cire bayanai (%(data_feature_count)s siffofi)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Iyakokin aiki (%(task_count)s ayyuka)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID na aiki"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Adadin gine-gine"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -822,7 +841,7 @@ msgstr ""
 "Ba a samu iyakokin aiki ba. Da fatan a fara raba aikin zuwa ayyuka ta "
 "amfani da maɓallin \"Split AOI\" da ke sama."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -831,7 +850,7 @@ msgstr ""
 "✓ An raba AOI cikin nasara! An samar da yankunan aiki %(task_count)s ta "
 "amfani da %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -923,29 +942,29 @@ msgstr "Tsarin bayanan yankunan aiki ba daidai ba ne."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ An ajiye rababbun ayyuka cikin nasara"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -954,7 +973,7 @@ msgstr ""
 "Yankin yana da %(area_km2)s km², wanda ya wuce iyakar %(area_limit)s km²."
 " Da fatan a rage yankin aikin."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -963,47 +982,47 @@ msgstr ""
 "Yankin yana da %(area_km2)s km². Manyan yankuna (>%(area_warn)s km²) na "
 "iya ɗaukar lokaci mai tsawo wajen sarrafawa."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Ana buƙatar GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Ba a samu polygon geometries ba. Yankin aikin dole ne ya kasance polygon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Zaɓin yanki yayi girma da yawa. Da fatan za a zaɓi yanki ƙasa da 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "ya kasa samar da tsantsar bayanai daga danyen bayanan API."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Ba a samu aikin ba."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Ba a samu aikin ba."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Ba a samu aikin ba."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Ba a samu aikin ba."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "An kasa loda fom na samfuri."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1011,25 +1030,50 @@ msgstr ""
 "An kirkiri wannan aikin da tsarin aiki mai sauki a FieldTM kuma an yi shi"
 " ne don tattara bayanan gine-gine domin inganta OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Yanki mara suna"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Yanki {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "ya ɓace ko bashi da lissafi."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "jigon jigo na aikin aikin ba shi da haɗin kai."
 
@@ -2163,8 +2207,8 @@ msgstr "Goge"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Zaɓuɓɓukan fom:"
 
@@ -2186,7 +2230,7 @@ msgstr "Ɗora GeoJSON na musamman"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ko"
 
@@ -2270,7 +2314,7 @@ msgid "Project Location"
 msgstr "Wurin aiki"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Fom ɗin Bincike"
 
@@ -2304,39 +2348,39 @@ msgstr ""
 "hotuna da bidiyo, shiga ODK Central sannan ka ɗora su a cikin saitunan "
 "fom."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "A shirye don taswira"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Ana loda lambar QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Ana loda fam ɗin haɗin gwiwar..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Saitin aiki"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Saitin aiki"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI na aikin"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Mataki na 3: Samu bayanai"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Raba AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Kammala aiki"
 
@@ -2392,7 +2436,7 @@ msgstr "polylines na layi"
 msgid "points"
 msgstr "maki"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "siffofi"
@@ -2427,7 +2471,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Ana saukewa..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Sauke bayanan OSM"
@@ -2444,7 +2488,7 @@ msgstr "Raba ta murabba'i"
 msgid "Split by buildings"
 msgstr "Raba ta gine-gine"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Sake raba"
@@ -2536,6 +2580,129 @@ msgstr "Ana ƙirƙirar aiki a %(project_type)s... Wannan na iya ɗaukar ɗan lok
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Kuskure:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2729,7 +2896,14 @@ msgstr ""
 "Ba a iya ƙirƙirar asusun mai kula ta atomatik ba. Shiga QFieldCloud a "
 "matsayin admin don kula da aikin."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Karɓi zaɓin ayyuka"
 
@@ -2858,95 +3032,104 @@ msgstr ""
 "fara da taswira mara komai domin masu zana taswira su tattara komai daga "
 "farko."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Fara da taswira mara komai"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Ɗora GeoJSON na musamman"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Tsoffin saitunan da aka ba da shawara suna aiki ga wannan aikin."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Abin da za a sauke"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Gine-ginen OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Hanyoyin OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Kiwon lafiya na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Bandakuna na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Addini na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Amfanin ƙasa na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Hanyoyin ruwa na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Wuraren ruwa na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Zubar da shara na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Ilimi na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Makabartu na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Kayayyakin more rayuwa na OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "siffofi"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligon"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilayi"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Batu"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Yi amfani da centroids (Don zazzage bayanan OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Mayar da polygons zuwa maki guda-guda."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Ana samar da cire bayanan OSM... Wannan na iya ɗaukar ɗan lokaci."
 
@@ -2979,11 +3162,21 @@ msgstr ""
 "aiki tare. Zaɓi yadda za a raba a ƙasa, duba sakamakon, sannan ka karɓa. "
 "Ko ka tsallake don amfani da duk yankin a matsayin aiki ɗaya."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Ana rabawa..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2992,79 +3185,79 @@ msgstr ""
 "Lokacin raba bisa yawan gine-gine, ana amfani da waɗannan abubuwan layi a"
 " matsayin iyakokin aiki na halitta."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Haɗa hanyoyi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Haɗa koguna"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Haɗa layin dogo"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Haɗa hanyoyin jirgi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Yadda za a raba"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Zaɓi hanya..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Ta yawan gine-gine (mai sauri)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Ta yawan gine-gine (siffofi masu tsafta)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Ta grid na yau da kullum"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Raba da takamaiman adadin ayyuka (zuwa nan ba da jimawa ba)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Matsakaicin gine-gine a kowane aiki:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Yawan ayyuka:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Girman murabba'in grid (mita)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Sake raba"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Ana raba AOI zuwa ayyuka... Wannan na iya ɗaukar ɗan lokaci."
 

--- a/src/backend/app/locales/hi/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/hi/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hi\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s विफल रहा।"
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "टाइलपैक एपीआई ने HTTP %(status_code)s लौटाया।"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML फॉर्म को XLSForm में बदलने में विफल रहा।"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "मान्य .xls या .xlsx फ़ाइल प्रदान करें"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "मान्य .xls या .xlsx फ़ाइल प्रदान करें"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "मान्य .xls या .xlsx फ़ाइल प्रदान करें"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "रॉ-डेटा-एपीआई में लॉगिन नहीं हो सका"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "कोई ज्यामिति मौजूद नहीं है"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "आपकी जियोजोन फ़ाइल अमान्य है।"
 
@@ -260,44 +260,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR कोड बनाते समय एक अप्रत्याशित त्रुटि हुई।"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "परियोजना (%(project_id)s) नहीं मिली।"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "केवल परियोजना प्रबंधक ही इस परियोजना को हटा सकता है।"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "परियोजना नहीं मिली।"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "त्रुटि: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "निम्नलिखित उपयोगकर्ता को प्रोजेक्ट संपादक के रूप में जोड़ा गया: %(names)s।"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' नहीं जोड़ा जा सका: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "अधिक सहयोगी जोड़ें"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud सहयोगियों को आमंत्रित करें"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -305,7 +305,7 @@ msgstr ""
 "इससे पहले कि आप मैपर्स को इस प्रोजेक्ट तक पहुंच प्रदान कर सकें, उनके पास "
 "QFieldCloud पर एक खाता होना चाहिए।"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -315,7 +315,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> पर एक "
 "निःशुल्क खाता बनाने के लिए कहें।"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -325,23 +325,23 @@ msgstr ""
 "लिए अल्पविराम से अलग) और सबमिट पर क्लिक करें। उन्हें संपादकों के रूप में "
 "जोड़ा जाएगा और मैपिंग शुरू करने के लिए QField में लॉग इन कर सकते हैं।"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "जैसे ऐलिस, बॉब, चार्ली"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "सहयोगी जोड़ें"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "कम से कम एक QFieldCloud उपयोगकर्ता नाम दर्ज करें।"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "इस प्रोजेक्ट के लिए QFieldCloud प्रोजेक्ट आईडी नहीं मिली।"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -349,18 +349,42 @@ msgstr ""
 "यह प्रोजेक्ट एक कस्टम QFieldCloud इंस्टेंस पर बनाया गया था। सहयोगियों को "
 "प्रबंधित करने के लिए QFieldCloud एडमिन टैब का उपयोग करें।"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "जियोजसन निर्यात केवल क्यूफील्ड परियोजनाओं के लिए उपलब्ध है।"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "यह प्रोजेक्ट अभी तक QFieldCloud प्रोजेक्ट से लिंक नहीं है।"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "जियोजसन निर्यात करने में विफल: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "परियोजना नहीं मिली या पहुँच अस्वीकृत है।"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -406,11 +430,6 @@ msgid ""
 msgstr ""
 "इस डिप्लॉयमेंट पर QField बेसमैप जोड़ना कॉन्फ़िगर नहीं है। %(config)s "
 "अनुपस्थित है।"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "परियोजना नहीं मिली या पहुँच अस्वीकृत है।"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -724,7 +743,7 @@ msgstr ""
 "फ़ाइल अपलोड करें।"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "परियोजना AOI"
 
@@ -797,25 +816,25 @@ msgstr ""
 "ODK URL, उपयोगकर्ता नाम और पासवर्ड (तीनों) प्रदान करें, या सर्वर डिफ़ॉल्ट"
 " का उपयोग करने के लिए सभी खाली छोड़ दें।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "डेटा एक्सट्रैक्ट (%(data_feature_count)s विशेषताएँ)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "कार्य सीमाएँ (%(task_count)s कार्य)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "कार्य आईडी"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "भवनों की संख्या"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -823,7 +842,7 @@ msgstr ""
 "कोई कार्य सीमा नहीं मिली। कृपया ऊपर दिए गए \"Split AOI\" बटन का उपयोग "
 "करके पहले परियोजना को कार्यों में विभाजित करें।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -832,7 +851,7 @@ msgstr ""
 "✓ AOI सफलतापूर्वक विभाजित किया गया! %(algorithm)s का उपयोग करके "
 "%(task_count)s कार्य क्षेत्र बनाए गए।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -923,29 +942,29 @@ msgstr "कार्य क्षेत्र डेटा का प्रा�
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ विभाजित कार्य सफलतापूर्वक सहेजे गए"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -954,7 +973,7 @@ msgstr ""
 "क्षेत्रफल %(area_km2)s km² है, जो %(area_limit)s km² सीमा से अधिक है। "
 "कृपया प्रोजेक्ट क्षेत्र घटाएँ।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -963,47 +982,47 @@ msgstr ""
 "क्षेत्रफल %(area_km2)s km² है। बड़े क्षेत्र (>%(area_warn)s km²) को "
 "संसाधित होने में अधिक समय लग सकता है।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON आवश्यक है"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "कोई बहुभुज ज्यामिति नहीं मिली। परियोजना क्षेत्र बहुभुज होना चाहिए।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "चयनित क्षेत्र बहुत बड़ा है. कृपया 200 km² से छोटा क्षेत्र चुनें।"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "कच्चे डेटा एपीआई से डेटा निकालने में विफल रहा।"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "परियोजना नहीं मिली।"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "परियोजना नहीं मिली।"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "परियोजना नहीं मिली।"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "परियोजना नहीं मिली।"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "टेम्पलेट फ़ॉर्म लोड नहीं हो सका।"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1012,25 +1031,50 @@ msgstr ""
 "OpenStreetMap को बेहतर बनाने के लिए भवन डेटा एकत्र करने हेतु बनाया गया "
 "है।"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "बेनाम क्षेत्र"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "क्षेत्र {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "प्रोजेक्ट की रूपरेखा गायब है या उसमें कोई ज्यामिति नहीं है।"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "प्रोजेक्ट रूपरेखा ज्यामिति में कोई निर्देशांक नहीं है।"
 
@@ -2164,8 +2208,8 @@ msgstr "साफ़ करें"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "फ़ॉर्म विकल्प:"
 
@@ -2187,7 +2231,7 @@ msgstr "कस्टम GeoJSON अपलोड करें"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "या"
 
@@ -2269,7 +2313,7 @@ msgid "Project Location"
 msgstr "परियोजना स्थान"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "सर्वे फॉर्म"
 
@@ -2303,39 +2347,39 @@ msgstr ""
 "अपलोड करनी हैं, तो ODK Central में लॉगिन करें और उन्हें फ़ॉर्म सेटिंग्स "
 "में अपलोड करें।"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "मानचित्रण के लिए तैयार"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR कोड लोड हो रहा है..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "सहयोगी प्रपत्र लोड हो रहा है..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "परियोजना सेटअप"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "परियोजना सेटअप"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "परियोजना AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "चरण 3: डेटा प्राप्त करें"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI विभाजित करें"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "परियोजना अंतिम करें"
 
@@ -2389,7 +2433,7 @@ msgstr "बहुरेखाएँ"
 msgid "points"
 msgstr "बिंदु"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "विशेषताएँ"
@@ -2425,7 +2469,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "डाउनलोड हो रहा है..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM डेटा डाउनलोड करें"
@@ -2442,7 +2486,7 @@ msgstr "वर्ग के अनुसार विभाजित करे�
 msgid "Split by buildings"
 msgstr "भवनों के अनुसार विभाजित करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "फिर से विभाजित करें"
@@ -2537,6 +2581,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "त्रुटि:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2730,7 +2897,14 @@ msgstr ""
 "प्रबंधक खाता स्वतः नहीं बनाया जा सका। परियोजना प्रबंधित करने के लिए admin"
 " के रूप में QFieldCloud में लॉगिन करें।"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "कार्य विकल्प स्वीकार करें"
 
@@ -2858,95 +3032,104 @@ msgstr ""
 "अपने प्रोजेक्ट क्षेत्र के लिए OpenStreetMap से मौजूदा फीचर खींचें, या "
 "खाली नक्शे से शुरू करें ताकि मैपर सब कुछ शुरू से एकत्र कर सकें।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "खाली नक्शे से शुरू करें"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "कस्टम GeoJSON अपलोड करें"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "इस परियोजना के लिए सुझाए गए डिफ़ॉल्ट सक्रिय हैं।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "क्या डाउनलोड करना है"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM भवन"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM सड़कें"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM स्वास्थ्य सेवाएँ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM शौचालय"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM धार्मिक स्थल"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM भूमि उपयोग"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM जलमार्ग"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM जल बिंदु"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM अपशिष्ट निपटान"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM शिक्षा"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM कब्रिस्तान"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM सुविधाएँ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "विशेषताएँ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "बहुभुज"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "बहुरेखा"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "बिंदु"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "केंद्रबिंदु उपयोग करें (OSM डेटा डाउनलोड के लिए)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "पॉलीगॉन को एकल बिंदुओं में बदलें।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM डेटा एक्सट्रैक्ट बनाया जा रहा है... इसमें थोड़ा समय लग सकता है।"
 
@@ -2979,11 +3162,21 @@ msgstr ""
 "सकें। नीचे विभाजन का तरीका चुनें, परिणाम का पूर्वावलोकन करें, फिर स्वीकार"
 " करें। या पूरे क्षेत्र को एक कार्य के रूप में उपयोग करने के लिए छोड़ दें।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "विभाजित किया जा रहा है..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2992,79 +3185,79 @@ msgstr ""
 "भवन संख्या के आधार पर विभाजित करते समय, ये रैखिक फीचर प्राकृतिक कार्य "
 "सीमाओं के रूप में उपयोग होते हैं।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "सड़कों को शामिल करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "नदियों को शामिल करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "रेलमार्ग शामिल करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "वायुमार्ग शामिल करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "कैसे विभाजित करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "एक तरीका चुनें..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "भवनों की संख्या से (तेज़)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "भवनों की संख्या से (साफ़ आकृतियां)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "नियमित ग्रिड से"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "विशिष्ट कार्य संख्या के अनुसार विभाजित करें (जल्द आ रहा है)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "प्रति कार्य औसत भवन:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "कार्यों की संख्या:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "ग्रिड वर्ग का आकार (मीटर)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "फिर से विभाजित करें"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI को कार्यों में विभाजित किया जा रहा है... इसमें थोड़ा समय लग सकता है।"
 

--- a/src/backend/app/locales/id/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/id/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: id\n"
@@ -162,31 +162,31 @@ msgstr "%(action)s gagal karena kesalahan koneksi upstream."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "mengembalikan HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Gagal mengonversi formulir YAML ke XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Berikan file .xls atau .xlsx yang valid"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Berikan file .xls atau .xlsx yang valid"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Berikan file .xls atau .xlsx yang valid"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Tidak dapat masuk ke data-mentah-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Tidak ada geometri"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "File geojson Anda tidak valid."
 
@@ -261,44 +261,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Terjadi kesalahan tak terduga saat membuat kode QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Proyek (%(project_id)s) tidak ditemukan."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Hanya manajer proyek yang dapat menghapus proyek ini."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Proyek tidak ditemukan."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Kesalahan: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Menambahkan pengguna berikut sebagai editor proyek: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Tidak dapat menambahkan '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Tambahkan lebih banyak kolaborator"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Undang kolaborator QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -306,7 +306,7 @@ msgstr ""
 "Pemeta harus memiliki akun di QFieldCloud sebelum Anda dapat memberi "
 "mereka akses ke proyek ini."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -316,7 +316,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -326,23 +326,23 @@ msgstr ""
 " beberapa pengguna) dan klik kirim. Mereka akan ditambahkan sebagai "
 "editor dan dapat masuk ke QField untuk memulai pemetaan."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "misalnya alice, bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Tambahkan kolaborator"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Masukkan setidaknya satu nama pengguna QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID proyek QFieldCloud tidak ditemukan untuk proyek ini."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -350,18 +350,42 @@ msgstr ""
 "Proyek ini dibuat pada instans QFieldCloud khusus. Gunakan tab Admin "
 "QFieldCloud untuk mengelola kolaborator."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Ekspor GeoJSON hanya tersedia untuk proyek QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Proyek ini belum ditautkan ke proyek QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Gagal mengekspor GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Proyek tidak ditemukan atau akses ditolak."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -407,11 +431,6 @@ msgid ""
 msgstr ""
 "Pelampiran peta dasar QField belum dikonfigurasi pada deployment ini. "
 "%(config)s tidak ada."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Proyek tidak ditemukan atau akses ditolak."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -726,7 +745,7 @@ msgstr ""
 "GeoJSON terlebih dahulu."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI Proyek"
 
@@ -799,25 +818,25 @@ msgstr ""
 "Berikan URL ODK, nama pengguna, dan kata sandi (ketiganya), atau biarkan "
 "kosong untuk menggunakan bawaan server."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Ekstrak Data (%(data_feature_count)s fitur)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Batas Tugas (%(task_count)s tugas)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID Tugas"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Jumlah Bangunan"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -825,7 +844,7 @@ msgstr ""
 "Tidak ditemukan batas tugas. Silakan bagi proyek menjadi tugas terlebih "
 "dahulu menggunakan tombol \"Split AOI\" di atas."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -834,7 +853,7 @@ msgstr ""
 "✓ AOI berhasil dibagi! Menghasilkan %(task_count)s area tugas menggunakan"
 " %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -926,29 +945,29 @@ msgstr "Format data area tugas tidak valid."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Tugas yang dibagi berhasil disimpan"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -957,7 +976,7 @@ msgstr ""
 "Area adalah %(area_km2)s km², yang melebihi batas %(area_limit)s km². "
 "Harap kurangi area proyek Anda."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -966,49 +985,49 @@ msgstr ""
 "Area adalah %(area_km2)s km². Area besar (>%(area_warn)s km²) mungkin "
 "membutuhkan waktu lebih lama untuk diproses."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON diperlukan"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Tidak ditemukan geometri poligon. Area proyek harus berupa poligon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "Area yang dipilih terlalu luas. Silakan pilih area yang lebih kecil dari "
 "200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Gagal menghasilkan ekstrak data dari API data mentah."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Proyek tidak ditemukan."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Proyek tidak ditemukan."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Proyek tidak ditemukan."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Proyek tidak ditemukan."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Gagal memuat formulir templat."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1017,25 +1036,50 @@ msgstr ""
 "ditujukan untuk mengumpulkan data bangunan guna meningkatkan "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Area Tanpa Nama"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Wilayah {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Garis besar proyek tidak ada atau tidak memiliki geometri."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Geometri garis besar proyek tidak memiliki koordinat."
 
@@ -2175,8 +2219,8 @@ msgstr "Hapus"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Opsi Formulir:"
 
@@ -2198,7 +2242,7 @@ msgstr "Unggah GeoJSON Kustom"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "atau"
 
@@ -2281,7 +2325,7 @@ msgid "Project Location"
 msgstr "Lokasi Proyek"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Formulir Survei"
 
@@ -2315,39 +2359,39 @@ msgstr ""
 "gambar dan video, masuklah ke ODK Central dan unggah melalui pengaturan "
 "formulir."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Siap untuk Pemetaan"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Memuat kode QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Memuat formulir kolaborator..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Penyiapan Proyek"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Penyiapan Proyek"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI Proyek"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Langkah 3: Ambil Data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Bagi AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finalisasi Proyek"
 
@@ -2401,7 +2445,7 @@ msgstr "garis"
 msgid "points"
 msgstr "titik"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "fitur"
@@ -2437,7 +2481,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Mengunduh..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Unduh Data OSM"
@@ -2454,7 +2498,7 @@ msgstr "Bagi Berdasarkan Kotak"
 msgid "Split by buildings"
 msgstr "Bagi Berdasarkan Bangunan"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Bagi Lagi"
@@ -2551,6 +2595,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Kesalahan:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2746,7 +2913,14 @@ msgstr ""
 "Akun manajer tidak dapat dibuat secara otomatis. Masuk ke QFieldCloud "
 "sebagai admin untuk mengelola proyek."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Terima Pilihan Tugas"
 
@@ -2875,95 +3049,104 @@ msgstr ""
 "atau mulai dengan peta kosong agar pemeta dapat mengumpulkan semuanya "
 "dari awal."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Mulai dengan peta kosong"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Unggah GeoJSON Kustom"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Setelan bawaan yang disarankan aktif untuk proyek ini."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Apa yang akan diunduh"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Bangunan OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Jalan OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Kesehatan OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Toilet OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Religi OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Tata Guna Lahan OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Jalur Air OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Titik Air OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Pembuangan Sampah OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Pendidikan OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Pemakaman OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Fasilitas OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "fitur"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligon"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilin"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Titik"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Gunakan centroid (Untuk unduhan data OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Ubah poligon menjadi titik tunggal."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Membuat ekstrak data OSM... Ini mungkin memerlukan beberapa saat."
 
@@ -2997,11 +3180,21 @@ msgstr ""
 "lalu terima. Atau lewati untuk menggunakan seluruh area sebagai satu "
 "tugas."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Membagi..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3010,79 +3203,79 @@ msgstr ""
 "Saat membagi berdasarkan jumlah bangunan, fitur linear ini digunakan "
 "sebagai batas tugas alami."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Sertakan jalan"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Sertakan sungai"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Sertakan rel kereta"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Sertakan jalur udara"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Cara membagi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Pilih metode..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Berdasarkan jumlah bangunan (lebih cepat)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Berdasarkan jumlah bangunan (bentuk lebih rapi)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Dengan kisi reguler"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Bagi Berdasarkan Jumlah Tugas Tertentu (Segera Hadir)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Rata-rata Bangunan per Tugas:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Jumlah Tugas:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Ukuran kotak kisi (meter)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Bagi Lagi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Membagi AOI menjadi tugas... Ini mungkin memerlukan beberapa saat."
 

--- a/src/backend/app/locales/ig/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ig/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ig\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s dara n'ihi njehie njikọ elu."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "weghachiri HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Ekpughị ịgbanwe ụdị YAML ka ọ bụrụ XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Nye faịlụ .xls ma ọ bụ .xlsx ziri ezi"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Nye faịlụ .xls ma ọ bụ .xlsx ziri ezi"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Nye faịlụ .xls ma ọ bụ .xlsx ziri ezi"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "enweghị ike ịbanye na raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Enweghị geometry dị"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "faịlụ geojson gị ezighi ezi."
 
@@ -256,44 +256,44 @@ msgstr "Nkwenye dara mgbe a na-ejikọ na sava maapụ. Lelee njirimara a haziri
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Njehie a na-atụghị anya ya mere mgbe a na-emepụta koodu QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Achọtaghị ọrụ (%(project_id)s)."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Naanị onye njikwa ọrụ nwere ike ihichapụ ọrụ a."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Achọtaghị ọrụ ahụ."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Njehie: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Agbakwunyere onye ọrụ ndị a dị ka ndị ndezi ọrụ: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Enweghị ike ịgbakwunye '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Tinyekwuo ndị mmekọ"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Kpọọ ndị mmekọ QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -301,7 +301,7 @@ msgstr ""
 "Ndị na-ese eserese ga-enwerịrị akaụntụ na QFieldCloud tupu ị nwee ike "
 "inye ha ohere maka ọrụ a."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -311,7 +311,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -321,23 +321,23 @@ msgstr ""
 "ọrụ) wee pịa nyefee. A ga-agbakwunye ha dị ka ndị ndezi ma nwee ike "
 "ịbanye na QField ka ịmalite eserese."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "eg. Alice, Bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Tinye ndị mmekọ"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Tinye opekata mpe otu aha njirimara QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Ahụghị ID ọrụ QFieldCloud maka ọrụ a."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -345,18 +345,42 @@ msgstr ""
 "Emepụtara ọrụ a na ihe atụ QFieldCloud omenala. Jiri taabụ Admin "
 "QFieldCloud jikwaa ndị na-emekọ ihe."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Mbupụ GeoJSON dị naanị maka ọrụ QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Ejikọtabeghị ọrụ a na ọrụ QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Mbupu GeoJSON agaghị eme: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Achọtaghị ọrụ ahụ ma ọ bụ a jụrụ ohere."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -400,11 +424,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "A hazibeghị ịtinye basemap QField na mbugharị a. %(config)s adịghị."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Achọtaghị ọrụ ahụ ma ọ bụ a jụrụ ohere."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -715,7 +734,7 @@ msgstr ""
 "mbụ."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI ọrụ"
 
@@ -788,25 +807,25 @@ msgstr ""
 "Nye ODK URL, aha njirimara, na okwuntughe (ha atọ niile), ma ọ bụ hapụ ha"
 " ka ha bụrụ efu iji jiri ndabara sava."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Mgbakwunye data (%(data_feature_count)s njirimara)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Ókè ọrụ (%(task_count)s ọrụ)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID Ọrụ"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Ọnụọgụ Ụlọ"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -814,7 +833,7 @@ msgstr ""
 "A hụghị ókè ọrụ. Biko kewaa ọrụ ahụ n'ime ọrụ mbụ site na iji bọtịnụ "
 "\"Split AOI\" dị n'elu."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -823,7 +842,7 @@ msgstr ""
 "✓ E kewara AOI nke ọma! E mepụtara mpaghara ọrụ %(task_count)s site na "
 "iji %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -914,29 +933,29 @@ msgstr "Ụdị data mpaghara ọrụ ezighi ezi."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ A chekwara ọrụ ndị e kewara nke ọma"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -945,7 +964,7 @@ msgstr ""
 "Mpaghara ahụ bụ %(area_km2)s km², nke gafere oke %(area_limit)s km². Biko"
 " belata mpaghara ọrụ gị."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -954,47 +973,47 @@ msgstr ""
 "Mpaghara ahụ bụ %(area_km2)s km². Mpaghara buru ibu (>%(area_warn)s km²) "
 "nwere ike iwe ogologo oge iji hazie."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "A chọrọ GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "A hụghị polygon geometry. Mpaghara ọrụ ga-abụ polygon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "ahọpụtara buru oke ibu. Biko họrọ mpaghara pere mpe karịa 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Egwughị iwepụta data sitere na API data raw."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Achọtaghị ọrụ ahụ."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Achọtaghị ọrụ ahụ."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Achọtaghị ọrụ ahụ."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Achọtaghị ọrụ ahụ."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Ebubataghị fọm ndebiri ahụ."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1002,25 +1021,50 @@ msgstr ""
 "E kere oru a site na usoro dị mfe na FieldTM ma e mere ya iji nakọta data"
 " ụlọ iji meziwanye OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Mpaghara Enweghị Aha"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Mpaghara {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "na-efu ma ọ bụ enweghị geometry."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "ihe ndeputa geometry enweghị nhazi."
 
@@ -2139,8 +2183,8 @@ msgstr "Kpochapụ"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Nhọrọ fọm:"
 
@@ -2162,7 +2206,7 @@ msgstr "Bulite GeoJSON omenala"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ma ọ bụ"
 
@@ -2241,7 +2285,7 @@ msgid "Project Location"
 msgstr "Ebe ọrụ"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Fọm Nnyocha"
 
@@ -2274,39 +2318,39 @@ msgstr ""
 "Ọ bụrụ na ịchọrọ ibulite faịlụ mgbasa ozi ọzọ na ọrụ a, dịka onyonyo na "
 "vidiyo, banye na ODK Central ma bulite ha na ntọala fọm."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Dị njikere maka ime maapụ"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Na-ebubata koodu QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Na-ebu ụdị onye mmekọ..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Nhazi ọrụ"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Nhazi ọrụ"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI ọrụ"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Nzọụkwụ 3: Nweta data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Kewaa AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Mechaa ọrụ"
 
@@ -2358,7 +2402,7 @@ msgstr "polyline"
 msgid "points"
 msgstr "point"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "njirimara"
@@ -2393,7 +2437,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Na-ebudata..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Budata data OSM"
@@ -2410,7 +2454,7 @@ msgstr "Kewaa site na square"
 msgid "Split by buildings"
 msgstr "Kewaa site na ụlọ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Kewaa ọzọ"
@@ -2502,6 +2546,129 @@ msgstr "Na-emepụta ọrụ na %(project_type)s... Nke a nwere ike iwe obere og
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Njehie:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2693,7 +2860,14 @@ msgstr ""
 "Enweghị ike ịmepụta akaụntụ onye njikwa na-akpaghị aka. Banye na "
 "QFieldCloud dịka admin iji jikwaa ọrụ ahụ."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Nabata nhọrọ ọrụ"
 
@@ -2820,95 +2994,104 @@ msgstr ""
 "Weta atụmatụ ndị dịbu na OpenStreetMap maka mpaghara oru ngo gị, ma ọ bụ "
 "bido na maapụ efu ka ndị na-eme maapụ chịkọta ihe niile site na mmalite."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Bido na maapụ efu"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Bulite GeoJSON omenala"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Ndabara a tụrụ aro na-arụ ọrụ maka ọrụ a."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Ihe a ga-ebudata"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Ụlọ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Ụzọ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Ahụike OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Ụlọ ịsa ahụ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Okpukpe OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Ojiji ala OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Ụzọ mmiri OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Ebe mmiri OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Ntụfu ahịhịa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Mmụta OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Ebe a na-eli ozu OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Akụrụngwa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "njirimara"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligon"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilaini"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Isi ihe"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Jiri centroid (Maka mbudata data OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Gbanwee polygons ka ha bụrụ isi ihe otu otu."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Na-emepụta mgbakwunye data OSM... Nke a nwere ike iwe obere oge."
 
@@ -2941,11 +3124,21 @@ msgstr ""
 "ọrụ n'otu oge. Họrọ otú a ga-esi kee ya n'okpuru, hụ nlele nsonaazụ, wee "
 "nabata ya. Ma ọ bụ gafee iji mpaghara dum dị ka otu ọrụ."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Na-ekewa..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2954,79 +3147,79 @@ msgstr ""
 "Mgbe a na-ekewa site na ọnụ ọgụgụ ụlọ, a na-eji atụmatụ ahịrị ndị a dị ka"
 " oke ọrụ eke."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Tinye ụzọ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Tinye osimiri"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Tinye ụzọ ígwè"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Tinye ụzọ ikuku"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Otu esi kee"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Họrọ usoro..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Site na ọnụ ọgụgụ ụlọ (ngwa ngwa)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Site na ọnụ ọgụgụ ụlọ (ụdị dị ọcha)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Site na grid mgbe niile"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Kewaa site na ọnụ ọgụgụ ọrụ akọwapụtara (na-abịa n’oge adịghị anya)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Ọnụ ọgụgụ ụlọ nkezi kwa ọrụ:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Ọnụọgụ ọrụ:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Nha square grid (mita)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Kewaa ọzọ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Na-ekewa AOI n'ime ọrụ... Nke a nwere ike iwe obere oge."
 

--- a/src/backend/app/locales/it/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/it/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s non riuscito a causa di un errore di connessione upstream."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "ha restituito HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Impossibile convertire il modulo YAML in XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Fornisci un file .xls o .xlsx valido"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Fornisci un file .xls o .xlsx valido"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Fornisci un file .xls o .xlsx valido"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Impossibile accedere a raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Nessuna geometria presente"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Il tuo file geojson non è valido."
 
@@ -261,44 +261,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Si è verificato un errore imprevisto durante la generazione del codice QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Progetto (%(project_id)s) non trovato."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Solo il responsabile del progetto può eliminare questo progetto."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Progetto non trovato."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Errore: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Aggiunti i seguenti utenti come editor del progetto: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Impossibile aggiungere '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Aggiungi altri collaboratori"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Invita collaboratori QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -306,7 +306,7 @@ msgstr ""
 "I mappatori devono avere un account su QFieldCloud prima di poter "
 "concedere loro l'accesso a questo progetto."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -316,7 +316,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -326,23 +326,23 @@ msgstr ""
 "più utenti) e fare clic su Invia. Verranno aggiunti come editor e "
 "potranno accedere a QField per avviare la mappatura."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "per esempio. Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Aggiungi collaboratori"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Immettere almeno un nome utente QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID progetto QFieldCloud non trovato per questo progetto."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -351,18 +351,42 @@ msgstr ""
 "Utilizzare la scheda Amministrazione QFieldCloud per gestire i "
 "collaboratori."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "L'esportazione GeoJSON è disponibile solo per i progetti QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Questo progetto non è ancora collegato a un progetto QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Impossibile esportare GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Progetto non trovato o accesso negato."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -413,11 +437,6 @@ msgid ""
 msgstr ""
 "Il collegamento della mappa di base QField non è configurato in questa "
 "distribuzione. Manca %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Progetto non trovato o accesso negato."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -734,7 +753,7 @@ msgstr ""
 "GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI del progetto"
 
@@ -807,25 +826,25 @@ msgstr ""
 "Fornisci URL ODK, nome utente e password (tutti e 3), oppure lasciali "
 "tutti vuoti per usare i valori predefiniti del server."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Estratto dati (%(data_feature_count)s elementi)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Confini dei task (%(task_count)s task)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID attività"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Numero di edifici"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -833,7 +852,7 @@ msgstr ""
 "Nessun confine dei task trovato. Suddividi prima il progetto in task "
 "usando il pulsante \"Suddividi AOI\" qui sopra."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -842,7 +861,7 @@ msgstr ""
 "✓ AOI suddivisa con successo! Generate %(task_count)s aree di task usando"
 " %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -937,29 +956,29 @@ msgstr "Formato dei dati delle aree di task non valido."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Task suddivisi salvati con successo"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -968,7 +987,7 @@ msgstr ""
 "L'area è %(area_km2)s km², superiore al limite di %(area_limit)s km². "
 "Riduci l'area del progetto."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -977,49 +996,49 @@ msgstr ""
 "L'area è %(area_km2)s km². Le aree grandi (>%(area_warn)s km²) possono "
 "richiedere più tempo per l'elaborazione."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON è obbligatorio"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Nessuna geometria poligonale trovata. L'area del progetto deve essere un "
 "poligono."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "L'area selezionata è troppo grande. Seleziona un'area inferiore a 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Impossibile generare l'estrazione dei dati dall'API dei dati grezzi."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Progetto non trovato."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Progetto non trovato."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Progetto non trovato."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Progetto non trovato."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Impossibile caricare il modulo modello."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1028,25 +1047,50 @@ msgstr ""
 "FieldTM ed è pensato per raccogliere dati sugli edifici per migliorare "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Area senza nome"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Area geografica {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Il contorno del progetto manca o non ha geometria."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "La geometria del contorno del progetto non ha coordinate."
 
@@ -2199,8 +2243,8 @@ msgstr "Cancella"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Opzioni del modulo:"
 
@@ -2222,7 +2266,7 @@ msgstr "Carica GeoJSON personalizzato"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "o"
 
@@ -2311,7 +2355,7 @@ msgid "Project Location"
 msgstr "Posizione del progetto"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Modulo del sondaggio"
 
@@ -2345,39 +2389,39 @@ msgstr ""
 "immagini e video, accedi a ODK Central e caricali nelle impostazioni del "
 "modulo."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Pronto per la mappatura"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Caricamento del codice QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Caricamento modulo collaboratore..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Configurazione progetto"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Configurazione progetto"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI del progetto"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Passaggio 3: Ottieni dati"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Suddividi AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finalizza progetto"
 
@@ -2435,7 +2479,7 @@ msgstr "polilinee"
 msgid "points"
 msgstr "punti"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "elementi"
@@ -2471,7 +2515,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Download in corso..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Scarica dati OSM"
@@ -2488,7 +2532,7 @@ msgstr "Suddividi per quadrato"
 msgid "Split by buildings"
 msgstr "Suddividi per edifici"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Suddividi di nuovo"
@@ -2585,6 +2629,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Errore:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2781,7 +2948,14 @@ msgstr ""
 "L'account del responsabile non può essere stato creato automaticamente. "
 "Accedi a QFieldCloud come amministratore per gestire il progetto."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Accetta scelte task"
 
@@ -2910,95 +3084,104 @@ msgstr ""
 "oppure inizia con una mappa vuota così i mappatori possono raccogliere "
 "tutto da zero."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Inizia con una mappa vuota"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Carica GeoJSON personalizzato"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "I valori predefiniti consigliati sono attivi per questo progetto."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Cosa scaricare"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Edifici OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Strade OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Sanità OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Servizi igienici OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Religioso OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Uso del suolo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Corsi d'acqua OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Punti d'acqua OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Smaltimento rifiuti OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Istruzione OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Cimiteri OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Servizi OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "elementi"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligono"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilinea"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Punto"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Usa centroidi (Per il download dei dati OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Converti i poligoni in singoli punti."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr ""
 "Generazione dell'estratto dati OSM in corso... Potrebbe richiedere "
@@ -3034,11 +3217,21 @@ msgstr ""
 "l'anteprima del risultato e accettalo. Oppure salta per usare tutta "
 "l'area come una sola attività."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Suddivisione in corso..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3047,79 +3240,79 @@ msgstr ""
 "Quando si divide per numero di edifici, queste entità lineari sono usate "
 "come confini naturali delle attività."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Includi strade"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Includi fiumi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Includi ferrovie"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Includi vie aeree"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Come dividere"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Scegli un metodo..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Per numero di edifici (più veloce)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Per numero di edifici (forme più pulite)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Con una griglia regolare"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Suddividi per numero specifico di task (prossimamente)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Media edifici per task:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Numero di compiti:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Dimensione del quadrato della griglia (metri)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Suddividi di nuovo"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Suddivisione dell'AOI in task... Potrebbe richiedere qualche istante."
 

--- a/src/backend/app/locales/ja/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ja/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s はアップストリーム接続エラーにより失敗し�
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "タイルパック API が HTTP %(status_code)s を返しました。"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML フォームから XLSForm への変換に失敗しました。"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "有効な .xls または .xlsx ファイルを指定してください"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "有効な .xls または .xlsx ファイルを指定してください"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "有効な .xls または .xlsx ファイルを指定してください"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-api にログインできませんでした"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "ジオメトリが存在しません"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "geojson ファイルが無効です。"
 
@@ -254,50 +254,50 @@ msgstr "マッピングサーバーへの接続時に認証に失敗しました
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR コードの生成中に予期しないエラーが発生しました。"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "プロジェクト (%(project_id)s) が見つかりません。"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "このプロジェクトを削除できるのはプロジェクト管理者のみです。"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "プロジェクトが見つかりません。"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "エラー: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "次のユーザーをプロジェクト編集者として追加しました: %(names)s。"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "「%(username)s」を追加できませんでした: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "コラボレーターをさらに追加する"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud のコラボレーターを招待する"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
 msgstr "マッパーにこのプロジェクトへのアクセスを許可するには、マッパーに QFieldCloud のアカウントが必要です。"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -307,7 +307,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> "
 "で無料アカウントを作成してもらいます。"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -317,23 +317,23 @@ msgstr ""
 "(複数ユーザーの場合はカンマ区切り)、「送信」をクリックします。これらは編集者として追加され、QField "
 "にログインしてマッピングを開始できます。"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "例えばアリス、ボブ、チャーリー"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "コラボレーターを追加する"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "少なくとも 1 つの QFieldCloud ユーザー名を入力します。"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "このプロジェクトの QFieldCloud プロジェクト ID が見つかりません。"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -341,18 +341,42 @@ msgstr ""
 "このプロジェクトはカスタム QFieldCloud インスタンス上に作成されました。 [QFieldCloud Admin] "
 "タブを使用してコラボレーターを管理します。"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON エクスポートは、QField プロジェクトでのみ使用できます。"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "このプロジェクトはまだ QFieldCloud プロジェクトにリンクされていません。"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON のエクスポートに失敗しました: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "プロジェクトが見つからないか、アクセスが拒否されました。"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -390,11 +414,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "このデプロイではQFieldベースマップ添付が設定されていません。%(config)s が不足しています。"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "プロジェクトが見つからないか、アクセスが拒否されました。"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -697,7 +716,7 @@ msgid ""
 msgstr "GeoJSON データが見つかりません。先に OSM データをダウンロードするか GeoJSON ファイルをアップロードしてください。"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "プロジェクト AOI"
 
@@ -760,38 +779,38 @@ msgid ""
 "to use server defaults."
 msgstr "ODK の URL、ユーザー名、パスワード (3 つすべて) を指定するか、サーバー既定値を使うためにすべて空欄のままにしてください。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "データ抽出 (%(data_feature_count)s 件の要素)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "タスク境界 (%(task_count)s 件のタスク)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "タスクID"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "建物数"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
 msgstr "タスク境界が見つかりません。まず上の「AOI を分割」ボタンを使ってプロジェクトをタスクに分割してください。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
 "%(algorithm)s."
 msgstr "✓ AOI の分割に成功しました。%(algorithm)s を使って %(task_count)s 個のタスク領域を生成しました。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -871,107 +890,132 @@ msgstr "無効なタスク領域データ形式です。"
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ 分割タスクを正常に保存しました"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
 "Please reduce your project area."
 msgstr "面積は %(area_km2)s km² で、%(area_limit)s km² の上限を超えています。プロジェクト範囲を小さくしてください。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
 "longer to process."
 msgstr "面積は %(area_km2)s km² です。大きな範囲 (>%(area_warn)s km²) は処理に時間がかかる場合があります。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON は必須です"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "ポリゴンのジオメトリが見つかりません。プロジェクト領域はポリゴンである必要があります。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "選択した領域が大きすぎます。 200 km² より小さいエリアを選択してください。"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "生データ API からのデータ抽出の生成に失敗しました。"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "プロジェクトが見つかりません。"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "プロジェクトが見つかりません。"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "プロジェクトが見つかりません。"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "プロジェクトが見つかりません。"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "テンプレートフォームの読み込みに失敗しました。"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
 msgstr "このプロジェクトは FieldTM の簡易ワークフローで作成され、OpenStreetMap を改善するための建物データ収集用に作られています。"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "名称未設定のエリア"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "エリア {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "プロジェクトのアウトラインが欠落しているか、ジオメトリがありません。"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "プロジェクトのアウトライン ジオメトリには座標がありません。"
 
@@ -2033,8 +2077,8 @@ msgstr "クリア"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "フォームオプション:"
 
@@ -2056,7 +2100,7 @@ msgstr "カスタム GeoJSON をアップロード"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "または"
 
@@ -2134,7 +2178,7 @@ msgid "Project Location"
 msgstr "プロジェクト場所"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "調査フォーム"
 
@@ -2167,39 +2211,39 @@ msgstr ""
 "画像や動画などの追加メディアファイルをこのプロジェクトにアップロードする必要がある場合は、ODK Central "
 "にログインしてフォーム設定からアップロードしてください。"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "マッピング準備完了"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR コードを読み込み中..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "共同作業者フォームを読み込んでいます..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "プロジェクト設定"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "プロジェクト設定"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "プロジェクト AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "ステップ 3: データ取得"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI を分割"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "プロジェクトを確定"
 
@@ -2251,7 +2295,7 @@ msgstr "ポリライン"
 msgid "points"
 msgstr "ポイント"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "要素"
@@ -2282,7 +2326,7 @@ msgstr "推奨ソースを更新しました (%(geom_label)s)。地図上のデ�
 msgid "Downloading..."
 msgstr "ダウンロード中..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM データをダウンロード"
@@ -2299,7 +2343,7 @@ msgstr "正方形で分割"
 msgid "Split by buildings"
 msgstr "建物単位で分割"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "再分割"
@@ -2391,6 +2435,129 @@ msgstr "%(project_type)s にプロジェクトを作成中... 少し時間がか
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "エラー:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2578,7 +2745,14 @@ msgid ""
 "      manage the project."
 msgstr "管理者アカウントを自動作成できませんでした。QFieldCloud に管理者としてログインしてプロジェクトを管理してください。"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "タスク選択を承認"
 
@@ -2697,95 +2871,104 @@ msgid ""
 "    map so mappers can collect everything from scratch."
 msgstr "プロジェクト範囲の既存フィーチャを OpenStreetMap から取得するか、空の地図から始めてマッパーがすべてを一から収集できるようにします。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "空の地図から始める"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "カスタム GeoJSON をアップロード"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "このプロジェクト向けの推奨デフォルト設定が有効です。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "ダウンロードするもの"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM 建物"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM 道路"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM 医療"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM トイレ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM 宗教施設"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM 土地利用"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM 水路"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM 給水地点"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM 廃棄物処理"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM 教育"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM 墓地"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM 施設"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "要素"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "ポリゴン"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "ポリライン"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "ポイント"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "重心を使用 (OSMデータダウンロード用)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "ポリゴンを単一ポイントに変換します。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM データ抽出を生成しています... 少し時間がかかる場合があります。"
 
@@ -2817,90 +3000,100 @@ msgstr ""
 "複数のマッパーが並行して作業できるよう、範囲を小さなタスクに分割します。下で分割方法を選び、結果をプレビューして承認します。スキップすると全範囲を"
 " 1 つのタスクとして使います。"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "分割中..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
 "          boundaries."
 msgstr "建物数で分割する場合、これらの線形フィーチャはタスクの自然な境界として使用されます。"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "道路を含める"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "河川を含める"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "鉄道を含める"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "航空路を含める"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "分割方法"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "方法を選択..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "建物数別（高速）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "建物数別（形状がきれい）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "通常グリッド別"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "指定したタスク数で分割 (近日対応)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "タスクあたり平均建物数:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "タスク数:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "グリッド正方形のサイズ（メートル）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "再分割"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI をタスクへ分割中... 少し時間がかかる場合があります。"
 

--- a/src/backend/app/locales/ne/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ne/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ne\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s अपस्ट्रिम जडान त्रुटि�
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API ले HTTP %(status_code)s फिर्ता गर्यो।"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML फारमलाई XLSForm मा रूपान्तरण गर्न असफल भयो।"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "मान्य .xls वा .xlsx फाइल प्रदान गर्नुहोस्"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "मान्य .xls वा .xlsx फाइल प्रदान गर्नुहोस्"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "मान्य .xls वा .xlsx फाइल प्रदान गर्नुहोस्"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-api मा लगइन गर्न सकिएन"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "कुनै ज्यामितिहरू उपस्थित छैनन्"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "तपाईको जियोजसन फाइल अमान्य छ।"
 
@@ -261,44 +261,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR कोड बनाउँदा एउटा अप्रत्याशित त्रुटि भयो।"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "परियोजना (%(project_id)s) भेटिएन।"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "यो परियोजना केवल परियोजना प्रबन्धकले मात्र मेट्न सक्छ।"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "परियोजना भेटिएन।"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "त्रुटि: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "परियोजना सम्पादकहरूको रूपमा निम्न प्रयोगकर्ता(हरू) थपियो: %(names)s।"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' थप्न सकिएन: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "थप सहयोगीहरू थप्नुहोस्"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud सहयोगीहरूलाई आमन्त्रित गर्नुहोस्"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -306,7 +306,7 @@ msgstr ""
 "तपाईंले तिनीहरूलाई यो परियोजनामा ​​पहुँच दिन सक्नु अघि म्यापरहरूसँग "
 "QFieldCloud मा खाता हुनुपर्छ।"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -316,7 +316,7 @@ msgstr ""
 " rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> मा "
 "नि:शुल्क खाता बनाउन लगाउनुहोस्।"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -327,23 +327,23 @@ msgstr ""
 "गर्नुहोस्। तिनीहरू सम्पादकको रूपमा थपिनेछन् र म्यापिङ सुरु गर्न QField मा"
 " लग इन गर्न सक्छन्।"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "जस्तै एलिस, बब, चार्ली"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "सहयोगीहरू थप्नुहोस्"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "कम्तिमा एउटा QFieldCloud प्रयोगकर्ता नाम प्रविष्ट गर्नुहोस्।"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "यस परियोजनाको लागि QFieldCloud परियोजना ID फेला परेन।"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -351,18 +351,42 @@ msgstr ""
 "यो परियोजना अनुकूलन QFieldCloud उदाहरणमा सिर्जना गरिएको थियो। सहकर्मीहरू "
 "व्यवस्थापन गर्न QFieldCloud Admin ट्याब प्रयोग गर्नुहोस्।"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON निर्यात QField परियोजनाहरूको लागि मात्र उपलब्ध छ।"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "यो परियोजना अझै QFieldCloud परियोजनासँग लिङ्क गरिएको छैन।"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON निर्यात गर्न असफल भयो: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "परियोजना भेटिएन वा पहुँच अस्वीकृत गरियो।"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -408,11 +432,6 @@ msgid ""
 msgstr ""
 "यो डिप्लोयमेन्टमा QField बेसम्याप जोडाइ कन्फिगर गरिएको छैन। %(config)s "
 "हराइरहेको छ।"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "परियोजना भेटिएन वा पहुँच अस्वीकृत गरियो।"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -728,7 +747,7 @@ msgstr ""
 "GeoJSON फाइल अपलोड गर्नुहोस्।"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "परियोजना AOI"
 
@@ -801,25 +820,25 @@ msgstr ""
 "ODK URL, प्रयोगकर्ता नाम, र पासवर्ड (तीनै) प्रदान गर्नुहोस्, वा सर्भरका "
 "पूर्वनिर्धारित मानहरू प्रयोग गर्न सबै खाली छोड्नुहोस्।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "डाटा एक्स्ट्र्याक्ट (%(data_feature_count)s विशेषताहरू)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "कार्य सिमानाहरू (%(task_count)s कार्यहरू)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "कार्य आईडी"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "भवन संख्या"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -827,7 +846,7 @@ msgstr ""
 "कुनै कार्य सिमाना भेटिएन। कृपया माथिको \"Split AOI\" बटन प्रयोग गरेर "
 "पहिले परियोजनालाई कार्यहरूमा विभाजन गर्नुहोस्।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -836,7 +855,7 @@ msgstr ""
 "✓ AOI सफलतापूर्वक विभाजन गरियो! %(algorithm)s प्रयोग गरेर %(task_count)s "
 "कार्य क्षेत्रहरू बनाइयो।"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -927,29 +946,29 @@ msgstr "अमान्य कार्य क्षेत्र डाटा �
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ विभाजित कार्यहरू सफलतापूर्वक सुरक्षित गरिए"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -958,7 +977,7 @@ msgstr ""
 "क्षेत्रफल %(area_km2)s km² छ, जुन %(area_limit)s km² सीमाभन्दा बढी हो। "
 "कृपया परियोजनाको क्षेत्र घटाउनुहोस्।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -967,49 +986,49 @@ msgstr ""
 "क्षेत्रफल %(area_km2)s km² छ। ठूला क्षेत्रहरू (>%(area_warn)s km²) "
 "प्रक्रिया गर्न बढी समय लाग्न सक्छ।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON आवश्यक छ"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "कुनै बहुभुज ज्यामिति भेटिएन। परियोजना क्षेत्र बहुभुज हुनुपर्छ।"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "चयन गरिएको क्षेत्र धेरै ठूलो छ। कृपया 200 km² भन्दा सानो क्षेत्र चयन "
 "गर्नुहोस्।"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "कच्चा डाटा API बाट डाटा एक्स्ट्र्याक्ट उत्पन्न गर्न असफल भयो।"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "परियोजना भेटिएन।"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "परियोजना भेटिएन।"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "परियोजना भेटिएन।"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "परियोजना भेटिएन।"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "टेम्प्लेट फारम लोड गर्न असफल भयो।"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1017,25 +1036,50 @@ msgstr ""
 "यो परियोजना FieldTM मा सरलीकृत कार्यप्रवाहबाट सिर्जना गरिएको हो र "
 "OpenStreetMap सुधार गर्न भवनसम्बन्धी डेटा सङ्कलनका लागि बनाइएको हो।"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "नाम नभएको क्षेत्र"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "क्षेत्र {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "परियोजना रूपरेखा हराइरहेको छ वा कुनै ज्यामिति छैन।"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "परियोजना रूपरेखा ज्यामितिमा कुनै समन्वयहरू छैनन्।"
 
@@ -2163,8 +2207,8 @@ msgstr "खाली गर्नुहोस्"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "फारम विकल्पहरू:"
 
@@ -2186,7 +2230,7 @@ msgstr "अनुकूलित GeoJSON अपलोड गर्नुहो�
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "वा"
 
@@ -2271,7 +2315,7 @@ msgid "Project Location"
 msgstr "परियोजनाको स्थान"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "सर्वेक्षण फाराम"
 
@@ -2305,39 +2349,39 @@ msgstr ""
 "भिडियो, अपलोड गर्न आवश्यक छ भने ODK Central मा लगइन गरेर फारम सेटिङमा "
 "अपलोड गर्नुहोस्।"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "नक्सांकनका लागि तयार"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR कोड लोड हुँदैछ..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "सहयोगी फारम लोड गर्दै..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "परियोजना सेटअप"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "परियोजना सेटअप"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "परियोजना AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "चरण 3: डाटा प्राप्त गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI विभाजन गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "परियोजना अन्तिम रूप दिनुहोस्"
 
@@ -2395,7 +2439,7 @@ msgstr "बहुरेखाहरू"
 msgid "points"
 msgstr "बिन्दुहरू"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "विशेषताहरू"
@@ -2431,7 +2475,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "डाउनलोड हुँदैछ..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM डाटा डाउनलोड गर्नुहोस्"
@@ -2448,7 +2492,7 @@ msgstr "वर्गका आधारमा विभाजन गर्नु
 msgid "Split by buildings"
 msgstr "भवनका आधारमा विभाजन गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "फेरि विभाजन गर्नुहोस्"
@@ -2543,6 +2587,129 @@ msgstr "%(project_type)s मा परियोजना सिर्जना �
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "त्रुटि:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2738,7 +2905,14 @@ msgstr ""
 "प्रबन्धक खाता स्वचालित रूपमा सिर्जना गर्न सकिएन। परियोजना व्यवस्थापन गर्न"
 " प्रशासकका रूपमा QFieldCloud मा लगइन गर्नुहोस्।"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "कार्य विकल्पहरू स्वीकार गर्नुहोस्"
 
@@ -2867,95 +3041,104 @@ msgstr ""
 "ल्याउनुहोस्, वा खाली नक्साबाट सुरु गर्नुहोस् ताकि म्यापरहरूले सबै कुरा "
 "सुरुबाट सङ्कलन गर्न सकून्।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "खाली नक्साबाट सुरु गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "अनुकूलित GeoJSON अपलोड गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "यस परियोजनाका लागि सिफारिस गरिएका पूर्वनिर्धारित सेटिङहरू सक्रिय छन्।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "के डाउनलोड गर्ने"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM भवनहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM सडकहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM स्वास्थ्य सेवा"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM शौचालयहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM धार्मिक स्थलहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM भूमि प्रयोग"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM जलमार्गहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM पानी बिन्दुहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM फोहोर व्यवस्थापन"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM शिक्षा"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM कब्रिस्तान"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM सुविधाहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "विशेषताहरू"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "बहुभुज"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "बहुरेखा"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "बिन्दु"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "केन्द्रबिन्दुहरू प्रयोग गर्नुहोस् (OSM डाटा डाउनलोडका लागि)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "बहुभुजहरूलाई एकल बिन्दुहरूमा रूपान्तरण गर्नुहोस्।"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM डाटा एक्स्ट्र्याक्ट तयार हुँदैछ... यसले केही समय लिन सक्छ।"
 
@@ -2989,11 +3172,21 @@ msgstr ""
 "गर्नुहोस्, अनि स्वीकार गर्नुहोस्। वा पूरा क्षेत्रलाई एउटै कार्यका रूपमा "
 "प्रयोग गर्न छोड्नुहोस्।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "विभाजन हुँदैछ..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3002,79 +3195,79 @@ msgstr ""
 "भवन सङ्ख्याअनुसार विभाजन गर्दा, यी रेखीय फिचरहरू प्राकृतिक कार्य सीमाका "
 "रूपमा प्रयोग हुन्छन्।"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "सडकहरू समावेश गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "नदीहरू समावेश गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "रेलमार्गहरू समावेश गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "विमानमार्गहरू समावेश गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "कसरी विभाजन गर्ने"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "विधि छान्नुहोस्..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "भवन सङ्ख्याअनुसार (छिटो)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "भवन सङ्ख्याअनुसार (सफा आकार)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "नियमित ग्रिडअनुसार"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "निर्दिष्ट कार्य सङ्ख्याअनुसार विभाजन गर्नुहोस् (चाँडै आउँदै)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "प्रति कार्य औसत भवन:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "कार्यहरूको संख्या:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "ग्रिड वर्गको आकार (मिटर)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "फेरि विभाजन गर्नुहोस्"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI लाई कार्यहरूमा विभाजन हुँदैछ... यसले केही समय लिन सक्छ।"
 

--- a/src/backend/app/locales/om/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/om/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: om\n"
@@ -164,31 +164,31 @@ msgstr "%(action)s sababa dogongora walqabsiisa olka'aatiin kufe."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "APIn Tilepack HTTP %(status_code)s deebise."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Unka YAML gara XLSForm jijjiiruu hin dandeenye."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Faayilii .xls ykn .xlsx sirrii dhiheessi"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Faayilii .xls ykn .xlsx sirrii dhiheessi"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Faayilii .xls ykn .xlsx sirrii dhiheessi"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Gara raw-data-api seenuu hin dandeenye"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Ji'oomeetiriiwwan hin jiran"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Faayilli geojson kee sirrii miti."
 
@@ -265,46 +265,46 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Koodii QR uumuun irratti dogoggorri hin eegamne uumame."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Pirojektiin (%(project_id)s) hin argamne."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Pirojektii kana haquu kan danda'u hoogganaa pirojektii qofa."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Pirojektiin hin argamne."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Dogoggora: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 "Fayyadamaa(wwan) armaan gadii akka gulaaltota pirojektiitti dabalameera: "
 "%(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' dabaluu hin dandeenye: %(reason)s ."
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Tumsitoota dabalataa itti dabalaa"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Tumsitoota QFieldCloud afeeraa"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -312,7 +312,7 @@ msgstr ""
 "Mappers pirojektii kanaaf qaqqabummaa isaaniif kennuu kee dura "
 "QFieldCloud irratti herrega qabaachuu qabu."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -322,7 +322,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a> irratti akka uumu taasisi."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -333,23 +333,23 @@ msgstr ""
 "Isaan akka gulaaltotaatti kan dabalaman yoo ta'u, kaartaa jalqabuuf gara "
 "QField seenuu danda'u."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "fkn. aliis, bob, chaarlii"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Tumsitoota itti dabali"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Yoo xiqqaate maqaa fayyadamaa QFieldCloud tokko galchi."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID pirojektii QFieldCloud pirojektii kanaaf hin argamne."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -357,18 +357,42 @@ msgstr ""
 "Pirojektiin kun fakkeenya QFieldCloud amala irratti uumame. Tumsa "
 "bulchuuf caancala Bulchiinsa QFieldCloud fayyadami."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Al-ergiin GeoJSON pirojektoota QField qofaaf argama."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Pirojektiin kun ammallee pirojektii QFieldCloud waliin wal hin hidhamne."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON erguu hin dandeenye: %(error)s ."
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Pirojektiin hin argamne ykn hayyamni dhorkameera."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -417,11 +441,6 @@ msgid ""
 msgstr ""
 "Maxxansi kaartaa buʼuuraa QField irratti qindaaʼinni hin taasifamne. "
 "%(config)s dhabameera."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Pirojektiin hin argamne ykn hayyamni dhorkameera."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -741,7 +760,7 @@ msgstr ""
 "GeoJSON olkaa'aa."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI pirojektii"
 
@@ -814,25 +833,25 @@ msgstr ""
 "ODK URL, maqaa fayyadamaa fi jecha icciitii (sadii isaanii) kenni, ykn "
 "hundumaa duwwaa dhiisi qindaa'ina seervaraa fayyadamuuf."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Baafata dataa (%(data_feature_count)s amaloota)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Daangaa hojii (%(task_count)s hojii)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID Hojii"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Lakkoofsa Gamoo"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -840,7 +859,7 @@ msgstr ""
 "Daangaan hojii hin argamne. Maaloo dura pirojektii kana gara "
 "hojiiwwanitti qoodi adabataa \"Split AOI\" armaan olii fayyadamuudhaan."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -849,7 +868,7 @@ msgstr ""
 "✓ AOI milkaa'inaan qoodame! %(algorithm)s fayyadamuun naannolee hojii "
 "%(task_count)s uumameera."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -940,29 +959,29 @@ msgstr "Foormaatin data naannoo hojii sirrii miti."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Hojii qoodaman milkaa'inaan olkaa'aman"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -971,7 +990,7 @@ msgstr ""
 "Bal'inni %(area_km2)s km² dha, kunis daangaa %(area_limit)s km² caala. "
 "Maaloo naannoo pirojektii xiqqeessi."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -980,47 +999,47 @@ msgstr ""
 "Bal'inni %(area_km2)s km² dha. Naannoleen gurguddoon (>%(area_warn)s km²)"
 " adeemsisuuf yeroo dheeraa fudhachuu danda'u."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON barbaachisaa dha"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Geometry polygon hin argamne. Naannoon pirojektii polygon ta'uu qaba."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Bal'inni filatame baay'ee guddaadha. Mee naannoo 200 km² gadi filadhu."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "API deetaa raw irraa deetaa baasuu maddisiisuu hin dandeenye."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Pirojektiin hin argamne."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Pirojektiin hin argamne."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Pirojektiin hin argamne."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Pirojektiin hin argamne."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Foormiin fakkeenyaa fe'amuu dadhabe."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1028,25 +1047,50 @@ msgstr ""
 "Pirojektiin kun adeemsa hojii salphifame FieldTM keessatti uumamee "
 "OpenStreetMap fooyyessuuf deetaa gamoo walitti qabuuf qophaaʼeera."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Naannoo maqaa hin qabne"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Naannoo {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Yaadni pirojektii dhabameera ykn ji’oomeetirii hin qabu."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Ji’oomeetiriin yaada pirojektii qindeessaa hin qabu."
 
@@ -2188,8 +2232,8 @@ msgstr "Haqi"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Filannoowwan unkaa:"
 
@@ -2211,7 +2255,7 @@ msgstr "GeoJSON dhuunfaa olkaa'i"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "yookaan"
 
@@ -2298,7 +2342,7 @@ msgid "Project Location"
 msgstr "Iddoo pirojektii"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Foormii Qorannoo"
 
@@ -2332,39 +2376,39 @@ msgstr ""
 "olkaa'uun barbaachise, ODK Central seeniitii qindaa'ina foormii keessatti"
 " olkaa'i."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Kaartaaf qophaa'eera"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Koodii QR fe'amaa jira..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Unka tumsaa fe'amaa jira..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Qophii pirojektii"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Qophii pirojektii"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI pirojektii"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Tarkaanfii 3: Data argadhu"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI qoodi"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Pirojektii xumuri"
 
@@ -2418,7 +2462,7 @@ msgstr "sararaawwan walitti aanan"
 msgid "points"
 msgstr "tuqaalee"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "amaloota"
@@ -2454,7 +2498,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Buufamaa jira..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Data OSM buufadhu"
@@ -2471,7 +2515,7 @@ msgstr "Iskuweeriin qoodi"
 msgid "Split by buildings"
 msgstr "Gamoodhaan qoodi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Ammas qoodi"
@@ -2566,6 +2610,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Dogoggora:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2762,7 +2929,14 @@ msgstr ""
 "Akaawuntiin hogganaa ofumaan uumamuu hin dandeenye. Pirojektii bulchuuf "
 "akka adminitti QFieldCloud seenaa."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Filannoo hojii fudhadhu"
 
@@ -2892,95 +3066,104 @@ msgstr ""
 "harkisi, yookaan kaartessitoonni hundumaa jalqabaa irraa akka walitti "
 "qaban kaartaa duwwaa irraa jalqabi."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Kaartaa duwwaa irraa jalqabi"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "GeoJSON dhuunfaa olkaa'i"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Qindaa'inni durtii gorfame pirojektii kanaaf hojiirra jira."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Maal buusuun akka barbaachisu"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Gamoo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Daandii OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Fayyaa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Mana fincaanii OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Amantii OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Itti fayyadama lafa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Daandii bishaanii OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Bakka bishaanii OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Baduu balfaa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Barnoota OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Awwaalaa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Tajaajila OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "amaloota"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Pooleegoonii"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Pooleelaayinii"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Tuqaa"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Centroid fayyadami (Buusii daataa OSM tiif)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Polygons gara tuqaalee tokko-tokkootti jijjiiri."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Baafata data OSM uumamaa jira... yeroo muraasa fudhachuu danda'a."
 
@@ -3014,11 +3197,21 @@ msgstr ""
 "dursee ilaali, achi booda fudhadhu. Yookaan naannoo guutuu akka hojii "
 "tokkootti fayyadamuuf darbii."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Qoodamaa jira..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3027,79 +3220,79 @@ msgstr ""
 "Yeroo lakkoofsa gamoowwaniin qoodamu, amaloonni sararaawoon kun daangaa "
 "hojii uumamaa ta'ee fayyadamu."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Daandiiwwan dabali"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Laga dabali"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Baaburaa dabali"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Karaa qilleensaa dabali"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Akkamitti qooduu"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Mala fili..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Lakkoofsa gamoowwaniin (saffisaa)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Lakkoofsa gamoowwaniin (boca qulqulluu)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Grid idilee fayyadamuun"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Lakkoofsa hojii murtaa'een qoodi (dhufuuf jira)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Giddugaleessa gamoo hojii tokkoof:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Lakkoofsa hojiiwwanii:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Hammamtaa iskuweerii grid (meetira)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Ammas qoodi"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI gara hojiiwwanitti qoodamaa jira... yeroo muraasa fudhachuu danda'a."
 

--- a/src/backend/app/locales/pt/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/pt/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:42+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: pt_br\n"
@@ -162,31 +162,31 @@ msgstr "%(action)s falhou devido a um erro de conexão upstream."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack retornou HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Falha ao converter o formulário YAML em XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Não foi possível fazer login na API de dados brutos"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Nenhuma geometria presente"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Seu arquivo geojson é inválido."
 
@@ -263,44 +263,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Ocorreu um erro inesperado ao gerar o código QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Projeto (%(project_id)s) não encontrado."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Somente o gerente do projeto pode excluir este projeto."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Projeto não encontrado."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Erro: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Adicionados os seguintes usuários como editores do projeto: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Não foi possível adicionar '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Adicione mais colaboradores"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Convide colaboradores do QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -308,7 +308,7 @@ msgstr ""
 "Os mapeadores devem ter uma conta no QFieldCloud antes que você possa "
 "conceder acesso a este projeto."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -318,7 +318,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -328,23 +328,23 @@ msgstr ""
 "para vários usuários) e clique em enviar. Eles serão adicionados como "
 "editores e poderão fazer login no QField para iniciar o mapeamento."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "por exemplo Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Adicionar colaboradores"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Insira pelo menos um nome de usuário do QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID do projeto QFieldCloud não encontrado para este projeto."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -352,18 +352,42 @@ msgstr ""
 "Este projeto foi criado em uma instância personalizada do QFieldCloud. "
 "Use a guia QFieldCloud Admin para gerenciar colaboradores."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "A exportação GeoJSON está disponível apenas para projetos QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Este projeto ainda não está vinculado a um projeto QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Falha ao exportar GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Projeto não encontrado ou acesso negado."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -410,11 +434,6 @@ msgid ""
 msgstr ""
 "A anexação do mapa base do QField não está configurada nesta implantação."
 " Falta %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Projeto não encontrado ou acesso negado."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -729,7 +748,7 @@ msgstr ""
 "arquivo GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Área de interesse do projeto"
 
@@ -804,25 +823,25 @@ msgstr ""
 "Forneça a URL do ODK, nome de usuário e senha (todos os 3), ou deixe "
 "todos em branco para usar os padrões do servidor."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Extração de dados (%(data_feature_count)s elementos)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Limites de tarefas (%(task_count)s tarefas)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID da Tarefa"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Número de Edifícios"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -830,7 +849,7 @@ msgstr ""
 "Nenhum limite de tarefa encontrado. Primeiro divida o projeto em tarefas "
 "usando o botão \"Dividir área de interesse\" acima."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -839,7 +858,7 @@ msgstr ""
 "✓ Área de interesse dividida com sucesso! %(task_count)s áreas de tarefas"
 " geradas usando %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -933,29 +952,29 @@ msgstr "Formato de dados de áreas de tarefas inválido."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Tarefas divididas salvas com sucesso"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -964,7 +983,7 @@ msgstr ""
 "A área é de %(area_km2)s km², o que excede o limite de %(area_limit)s "
 "km². Reduza a área do projeto."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -973,49 +992,49 @@ msgstr ""
 "A área é de %(area_km2)s km². Áreas grandes (>%(area_warn)s km²) podem "
 "demorar mais tempo a processar."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON é obrigatório"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Nenhuma geometria de polígono encontrada. A área do projeto deve ser um "
 "polígono."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "A área selecionada é muito grande. Selecione uma área menor que 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Falha ao gerar extração de dados da API de dados brutos."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Falha ao carregar o formulário modelo."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1024,25 +1043,50 @@ msgstr ""
 "e foi feito para recolher dados de edifícios para melhorar o "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Área sem nome"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Área {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "O contorno do projeto está faltando ou não possui geometria."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "A geometria do contorno do projeto não possui coordenadas."
 
@@ -2190,8 +2234,8 @@ msgstr "Limpar"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Opções do formulário:"
 
@@ -2213,7 +2257,7 @@ msgstr "Enviar GeoJSON personalizado"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ou"
 
@@ -2302,7 +2346,7 @@ msgid "Project Location"
 msgstr "Localização do projeto"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Formulário do questionário"
 
@@ -2336,39 +2380,39 @@ msgstr ""
 "imagens e vídeos, faça login no ODK Central e envie-os nas configurações "
 "do formulário."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Pronto para mapeamento"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Carregando código QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Carregando formulário de colaborador..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Configuração do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Configuração do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Área de interesse do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Passo 3: Obter dados"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Dividir área de interesse"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finalizar projeto"
 
@@ -2422,7 +2466,7 @@ msgstr "polilinhas"
 msgid "points"
 msgstr "pontos"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "elementos"
@@ -2458,7 +2502,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Baixando..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Baixar dados OSM"
@@ -2475,7 +2519,7 @@ msgstr "Dividir por quadrado"
 msgid "Split by buildings"
 msgstr "Dividir por edifícios"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Dividir novamente"
@@ -2570,6 +2614,129 @@ msgstr "Criando projeto em %(project_type)s... Isso pode levar um momento."
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Erro:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2765,7 +2932,14 @@ msgstr ""
 "A conta do gerente não pôde ser criada automaticamente. Faça login no "
 "QFieldCloud como administrador para gerenciar o projeto."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Aceitar escolhas de tarefas"
 
@@ -2894,95 +3068,104 @@ msgstr ""
 " ou comece com um mapa vazio para que os mapeadores recolham tudo do "
 "zero."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Começar com mapa vazio"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Enviar GeoJSON personalizado"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Os padrões recomendados estão ativos para este projeto."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "O que descarregar"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Edifícios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Rodovias OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Saúde OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Banheiros OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Locais religiosos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Uso do solo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Cursos d'água OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Pontos de água OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Descarte de resíduos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Educação OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Cemitérios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Equipamentos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "elementos"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Polígono"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilinha"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Ponto"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Usar centroides (Para descarga de dados OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Converter polígonos em pontos únicos."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Gerando extração de dados OSM... Isso pode levar um momento."
 
@@ -3016,11 +3199,21 @@ msgstr ""
 "o resultado e aceite-o. Ou ignore para usar toda a área como uma só "
 "tarefa."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Dividindo..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3029,79 +3222,79 @@ msgstr ""
 "Ao dividir por número de edifícios, estes elementos lineares são usados "
 "como limites naturais das tarefas."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Incluir estradas"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Incluir rios"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Incluir ferrovias"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Incluir vias aéreas"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Como dividir"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Escolha um método..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Por número de edifícios (mais rápido)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Por número de edifícios (formas mais limpas)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Por uma grelha regular"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Dividir por número específico de tarefas (em breve)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Edifícios méd. por tarefa:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Número de tarefas:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Tamanho do quadrado da grelha (metros)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Dividir novamente"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Dividindo área de interesse em tarefas... Isso pode levar um momento."
 

--- a/src/backend/app/locales/pt_br/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/pt_br/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:42+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: pt_br\n"
@@ -162,31 +162,31 @@ msgstr "%(action)s falhou devido a um erro de conexão upstream."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack retornou HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Falha ao converter o formulário YAML em XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Forneça um arquivo .xls ou .xlsx válido"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Não foi possível fazer login na API de dados brutos"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Nenhuma geometria presente"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Seu arquivo geojson é inválido."
 
@@ -263,44 +263,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Ocorreu um erro inesperado ao gerar o código QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Projeto (%(project_id)s) não encontrado."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Somente o gerente do projeto pode excluir este projeto."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Projeto não encontrado."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Erro: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Adicionados os seguintes usuários como editores do projeto: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Não foi possível adicionar '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Adicione mais colaboradores"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Convide colaboradores do QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -308,7 +308,7 @@ msgstr ""
 "Os mapeadores devem ter uma conta no QFieldCloud antes que você possa "
 "conceder acesso a este projeto."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -318,7 +318,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -328,23 +328,23 @@ msgstr ""
 "para vários usuários) e clique em enviar. Eles serão adicionados como "
 "editores e poderão fazer login no QField para iniciar o mapeamento."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "por exemplo Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Adicionar colaboradores"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Insira pelo menos um nome de usuário do QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID do projeto QFieldCloud não encontrado para este projeto."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -352,18 +352,42 @@ msgstr ""
 "Este projeto foi criado em uma instância personalizada do QFieldCloud. "
 "Use a guia QFieldCloud Admin para gerenciar colaboradores."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "A exportação GeoJSON está disponível apenas para projetos QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Este projeto ainda não está vinculado a um projeto QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Falha ao exportar GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Projeto não encontrado ou acesso negado."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -410,11 +434,6 @@ msgid ""
 msgstr ""
 "A anexação do mapa base do QField não está configurada nesta implantação."
 " Falta %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Projeto não encontrado ou acesso negado."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -729,7 +748,7 @@ msgstr ""
 "arquivo GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Área de interesse do projeto"
 
@@ -804,25 +823,25 @@ msgstr ""
 "Forneça a URL do ODK, nome de usuário e senha (todos os 3), ou deixe "
 "todos em branco para usar os padrões do servidor."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Extração de dados (%(data_feature_count)s elementos)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Limites de tarefas (%(task_count)s tarefas)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID da Tarefa"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Número de Edifícios"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -830,7 +849,7 @@ msgstr ""
 "Nenhum limite de tarefa encontrado. Primeiro divida o projeto em tarefas "
 "usando o botão \"Dividir área de interesse\" acima."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -839,7 +858,7 @@ msgstr ""
 "✓ Área de interesse dividida com sucesso! %(task_count)s áreas de tarefas"
 " geradas usando %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -933,29 +952,29 @@ msgstr "Formato de dados de áreas de tarefas inválido."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Tarefas divididas salvas com sucesso"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -964,7 +983,7 @@ msgstr ""
 "A área é de %(area_km2)s km², o que excede o limite de %(area_limit)s "
 "km². Reduza a área do projeto."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -973,49 +992,49 @@ msgstr ""
 "A área é de %(area_km2)s km². Áreas grandes (>%(area_warn)s km²) podem "
 "levar mais tempo para processar."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON é obrigatório"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Nenhuma geometria de polígono encontrada. A área do projeto deve ser um "
 "polígono."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "A área selecionada é muito grande. Selecione uma área menor que 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Falha ao gerar extração de dados da API de dados brutos."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Projeto não encontrado."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Falha ao carregar o formulário modelo."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1024,25 +1043,50 @@ msgstr ""
 "e foi feito para coletar dados de edifícios para melhorar o "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Área sem nome"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Área {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "O contorno do projeto está faltando ou não possui geometria."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "A geometria do contorno do projeto não possui coordenadas."
 
@@ -2190,8 +2234,8 @@ msgstr "Limpar"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Opções do formulário:"
 
@@ -2213,7 +2257,7 @@ msgstr "Enviar GeoJSON personalizado"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "ou"
 
@@ -2300,7 +2344,7 @@ msgid "Project Location"
 msgstr "Localização do projeto"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Formulário do formulário"
 
@@ -2334,39 +2378,39 @@ msgstr ""
 "imagens e vídeos, faça login no ODK Central e envie-os nas configurações "
 "do formulário."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Pronto para mapeamento"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Carregando código QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Carregando formulário de colaborador..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Configuração do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Configuração do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Área de interesse do projeto"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Passo 3: Obter dados"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Dividir área de interesse"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Finalizar projeto"
 
@@ -2420,7 +2464,7 @@ msgstr "polilinhas"
 msgid "points"
 msgstr "pontos"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "elementos"
@@ -2456,7 +2500,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Baixando..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Baixar dados OSM"
@@ -2473,7 +2517,7 @@ msgstr "Dividir por quadrado"
 msgid "Split by buildings"
 msgstr "Dividir por edifícios"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Dividir novamente"
@@ -2568,6 +2612,129 @@ msgstr "Criando projeto em %(project_type)s... Isso pode levar um momento."
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Erro:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2763,7 +2930,14 @@ msgstr ""
 "A conta do gerente não pôde ser criada automaticamente. Faça login no "
 "QFieldCloud como administrador para gerenciar o projeto."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Aceitar escolhas de tarefas"
 
@@ -2892,95 +3066,104 @@ msgstr ""
 " ou comece com um mapa vazio para que os mapeadores recolham tudo do "
 "zero."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Começar com mapa vazio"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Enviar GeoJSON personalizado"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Os padrões recomendados estão ativos para este projeto."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "O que desenviar"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Edifícios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Rodovias OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Saúde OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Banheiros OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Locais religiosos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Uso do solo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Cursos d'água OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Pontos de água OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Descarte de resíduos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Educação OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Cemitérios OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Equipamentos OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "elementos"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Polígono"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilinha"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Ponto"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Usar centroides (Para download de dados OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Converter polígonos em pontos únicos."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Gerando extração de dados OSM... Isso pode levar um momento."
 
@@ -3014,11 +3197,21 @@ msgstr ""
 "o resultado e aceite-o. Ou ignore para usar toda a área como uma só "
 "tarefa."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Dividindo..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3027,79 +3220,79 @@ msgstr ""
 "Ao dividir por número de edifícios, estes elementos lineares são usados "
 "como limites naturais das tarefas."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Incluir estradas"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Incluir rios"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Incluir ferrovias"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Incluir vias aéreas"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Como dividir"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Escolha um método..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Por número de edifícios (mais rápido)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Por número de edifícios (formas mais limpas)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Por uma grade regular"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Dividir por número específico de tarefas (em breve)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Edifícios méd. por tarefa:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Número de tarefas:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Tamanho do quadrado da grade (metros)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Dividir novamente"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Dividindo área de interesse em tarefas... Isso pode levar um momento."
 

--- a/src/backend/app/locales/ru/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ru/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -166,31 +166,31 @@ msgstr "%(action)s не удалось выполнить из-за ошибки
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack вернул HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Не удалось преобразовать форму YAML в XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Укажите корректный файл .xls или .xlsx"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Укажите корректный файл .xls или .xlsx"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Укажите корректный файл .xls или .xlsx"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Не удалось войти в raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Геометрия отсутствует"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Ваш файл geojson недействителен."
 
@@ -269,44 +269,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "При создании QR-кода произошла непредвиденная ошибка."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Проект (%(project_id)s) не найден."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Удалить этот проект может только менеджер проекта."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Проект не найден."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Ошибка: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "В качестве редакторов проекта добавлены следующие пользователи: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Не удалось добавить «%(username)s»: %(reason)s."
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Добавить соавторов"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Пригласите сотрудников QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -314,7 +314,7 @@ msgstr ""
 "Прежде чем вы сможете предоставить им доступ к этому проекту, у "
 "картографов должна быть учетная запись в QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -324,7 +324,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -334,23 +334,23 @@ msgstr ""
 "нескольких пользователей) и нажмите «Отправить». Они будут добавлены в "
 "качестве редакторов и смогут войти в QField, чтобы начать сопоставление."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "например Элис, Боб, Чарли"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Добавить соавторов"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Введите хотя бы одно имя пользователя QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Идентификатор проекта QFieldCloud для этого проекта не найден."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -359,18 +359,42 @@ msgstr ""
 "Используйте вкладку «Администратор» QFieldCloud для управления "
 "соавторами."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Экспорт GeoJSON доступен только для проектов QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Этот проект еще не связан с проектом QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Не удалось экспортировать GeoJSON: %(error)s."
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Проект не найден или доступ запрещён."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -416,11 +440,6 @@ msgid ""
 msgstr ""
 "Прикрепление базовой карты QField не настроено в этом развертывании. "
 "Отсутствует %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Проект не найден или доступ запрещён."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -735,7 +754,7 @@ msgstr ""
 " GeoJSON."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Область интереса проекта"
 
@@ -808,25 +827,25 @@ msgstr ""
 "Укажите URL ODK, имя пользователя и пароль (все 3 поля) либо оставьте всё"
 " пустым, чтобы использовать настройки сервера по умолчанию."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Выгрузка данных (%(data_feature_count)s объектов)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Границы задач (%(task_count)s задач)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID задачи"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Количество зданий"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -834,7 +853,7 @@ msgstr ""
 "Границы задач не найдены. Сначала разделите проект на задачи, используя "
 "кнопку \"Split AOI\" выше."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -843,7 +862,7 @@ msgstr ""
 "✓ Область интереса успешно разделена. Создано %(task_count)s областей "
 "задач с помощью %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -935,29 +954,29 @@ msgstr "Неверный формат данных областей задач."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Разделённые задачи успешно сохранены"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -966,7 +985,7 @@ msgstr ""
 "Площадь составляет %(area_km2)s км², что превышает лимит %(area_limit)s "
 "км². Уменьшите область проекта."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -975,49 +994,49 @@ msgstr ""
 "Площадь составляет %(area_km2)s км². Большие области (>%(area_warn)s км²)"
 " могут обрабатываться дольше."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Требуется GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Полигональные геометрии не найдены. Область проекта должна быть полигоном."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "Выбранная область слишком велика. Пожалуйста, выберите область размером "
 "менее 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Не удалось создать экстракт данных из API необработанных данных."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Проект не найден."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Проект не найден."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Проект не найден."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Проект не найден."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Не удалось загрузить шаблон формы."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1026,25 +1045,50 @@ msgstr ""
 "FieldTM и предназначен для сбора данных о зданиях, чтобы улучшить "
 "OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Безымянная область"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Область {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Контур проекта отсутствует или не имеет геометрии."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Геометрия контура проекта не имеет координат."
 
@@ -2192,8 +2236,8 @@ msgstr "Очистить"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Параметры формы:"
 
@@ -2215,7 +2259,7 @@ msgstr "Загрузить собственный GeoJSON"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "или"
 
@@ -2300,7 +2344,7 @@ msgid "Project Location"
 msgstr "Расположение проекта"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Форма опроса"
 
@@ -2334,39 +2378,39 @@ msgstr ""
 "например изображения и видео, войдите в ODK Central и загрузите их в "
 "настройках формы."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Готово к картографированию"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Загрузка QR-кода..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Загрузка формы для соавтора..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Настройка проекта"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Настройка проекта"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Область интереса проекта"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Шаг 3: Получить данные"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Разделить AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Завершить проект"
 
@@ -2424,7 +2468,7 @@ msgstr "полилинии"
 msgid "points"
 msgstr "точки"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "объекты"
@@ -2460,7 +2504,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Загрузка..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Скачать данные OSM"
@@ -2477,7 +2521,7 @@ msgstr "Разделить на квадраты"
 msgid "Split by buildings"
 msgstr "Разделить по зданиям"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Разделить снова"
@@ -2571,6 +2615,129 @@ msgstr "Создание проекта в %(project_type)s... Это может
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Ошибка:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2766,7 +2933,14 @@ msgstr ""
 "Не удалось автоматически создать учетную запись менеджера. Войдите в "
 "QFieldCloud как администратор, чтобы управлять проектом."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Принять выбор задач"
 
@@ -2890,95 +3064,104 @@ msgstr ""
 "Загрузите существующие объекты из OpenStreetMap для области проекта или "
 "начните с пустой карты, чтобы картировщики собрали всё с нуля."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Начать с пустой карты"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Загрузить собственный GeoJSON"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Для этого проекта активны рекомендуемые настройки по умолчанию."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Что загрузить"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Здания OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Дороги OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Медицинские объекты OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Туалеты OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Религиозные объекты OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Землепользование OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Водные пути OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Точки воды OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Утилизация отходов OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Образование OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Кладбища OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Объекты инфраструктуры OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "объекты"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Полигон"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Полилиния"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Точка"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Использовать центроиды (Для загрузки данных OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Преобразовать полигоны в отдельные точки."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Формирование выгрузки данных OSM... Это может занять некоторое время."
 
@@ -3012,11 +3195,21 @@ msgstr ""
 " и примите его. Или пропустите, чтобы использовать всю область как одну "
 "задачу."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Разделение..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3025,79 +3218,79 @@ msgstr ""
 "При делении по количеству зданий эти линейные объекты используются как "
 "естественные границы задач."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Включить дороги"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Включить реки"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Включить железные дороги"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Включить воздушные пути"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Как разделить"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Выберите метод..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "По количеству зданий (быстрее)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "По количеству зданий (более аккуратные формы)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "По регулярной сетке"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Разделить на заданное число задач (скоро)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Среднее число зданий на задачу:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Количество задач:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Размер квадрата сетки (метры)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Разделить снова"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Разделение AOI на задачи... Это может занять некоторое время."
 

--- a/src/backend/app/locales/sw/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/sw/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 17:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: sw\n"
@@ -161,31 +161,31 @@ msgstr ""
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API imerudisha HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Imeshindwa kubadilisha fomu ya YAML hadi XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Toa faili halali la .xls au .xlsx"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Toa faili halali la .xls au .xlsx"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Toa faili halali la .xls au .xlsx"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Haikuweza kuingia kwa ghafi-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Hakuna jiometri zilizopo"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Faili yako ya geojson ni batili."
 
@@ -262,44 +262,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Hitilafu isiyotarajiwa imetokea wakati wa kutengeneza msimbo wa QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Mradi (%(project_id)s) haujapatikana."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Ni msimamizi wa mradi pekee anayeweza kufuta mradi huu."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Mradi haujapatikana."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Hitilafu: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Aliongeza watumiaji wafuatao kama wahariri wa mradi: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Haikuweza kuongeza '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Ongeza washirika zaidi"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Alika washirika wa QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -307,7 +307,7 @@ msgstr ""
 "Wasanii ramani lazima wawe na akaunti kwenye QFieldCloud kabla ya kuwapa "
 "ufikiaji wa mradi huu."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -317,7 +317,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -327,23 +327,23 @@ msgstr ""
 "kwa koma kwa watumiaji wengi) na ubofye wasilisha. Wataongezwa kama "
 "wahariri na wanaweza kuingia kwenye QField ili kuanza kuchora ramani."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "k.m. alice, bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Ongeza washirika"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Weka angalau jina moja la mtumiaji la QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Kitambulisho cha mradi wa QFieldCloud hakijapatikana kwa mradi huu."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -351,18 +351,42 @@ msgstr ""
 "Mradi huu uliundwa kwa mfano maalum wa QFieldCloud. Tumia kichupo cha "
 "Msimamizi wa QFieldCloud ili kudhibiti washirika."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Usafirishaji wa GeoJSON unapatikana kwa miradi ya QField pekee."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Mradi huu bado haujaunganishwa na mradi wa QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Imeshindwa kuhamisha GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Mradi haujapatikana au ruhusa imekataliwa."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -411,11 +435,6 @@ msgid ""
 msgstr ""
 "Kuambatanisha ramani msingi ya QField hakujasanidiwa kwenye usambazaji "
 "huu. %(config)s inakosekana."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Mradi haujapatikana au ruhusa imekataliwa."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -736,7 +755,7 @@ msgstr ""
 "pakia faili la GeoJSON kwanza."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI ya mradi"
 
@@ -809,25 +828,25 @@ msgstr ""
 "Toa URL ya ODK, jina la mtumiaji, na nywila (zote 3), au ziache zote wazi"
 " ili kutumia chaguo-msingi za seva."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Dondoo la data (%(data_feature_count)s vipengele)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Mipaka ya kazi (%(task_count)s kazi)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "Kitambulisho cha jukumu"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Idadi ya majengo"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -835,7 +854,7 @@ msgstr ""
 "Hakuna mipaka ya kazi iliyopatikana. Tafadhali gawanya mradi katika kazi "
 "kwanza kwa kutumia kitufe cha \"Gawanya AOI\" hapo juu."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -844,7 +863,7 @@ msgstr ""
 "✓ AOI imegawanywa kwa mafanikio! Maeneo ya kazi %(task_count)s "
 "yamezalishwa kwa kutumia %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -935,29 +954,29 @@ msgstr "Muundo wa data ya maeneo ya kazi si sahihi."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Kazi zilizogawanywa zimehifadhiwa kwa mafanikio"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -966,7 +985,7 @@ msgstr ""
 "Eneo ni %(area_km2)s km², ambalo linazidi kikomo cha %(area_limit)s km². "
 "Tafadhali punguza eneo la mradi wako."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -975,51 +994,51 @@ msgstr ""
 "Eneo ni %(area_km2)s km². Maeneo makubwa (>%(area_warn)s km²) yanaweza "
 "kuchukua muda mrefu zaidi kuchakatwa."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON inahitajika"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr ""
 "Hakuna jiometri za poligoni zilizopatikana. Eneo la mradi lazima liwe "
 "poligoni."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "Eneo lililochaguliwa ni kubwa mno. Tafadhali chagua eneo lisilozidi km² "
 "200."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Imeshindwa kutoa dondoo la data kutoka kwa API ya data ghafi."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Mradi haujapatikana."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Mradi haujapatikana."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Mradi haujapatikana."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Mradi haujapatikana."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Imeshindikana kupakia fomu ya kiolezo."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1027,25 +1046,50 @@ msgstr ""
 "Mradi huu uliundwa kwa mtiririko rahisi wa kazi katika FieldTM na "
 "umeundwa kukusanya data za majengo ili kuboresha OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Eneo Lisilo na Jina"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Eneo {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "haupo au hauna jiometri."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Jiometri ya muhtasari wa mradi haina viwianishi."
 
@@ -2195,8 +2239,8 @@ msgstr "Futa"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Chaguo za fomu:"
 
@@ -2218,7 +2262,7 @@ msgstr "Pakia GeoJSON maalum"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "au"
 
@@ -2304,7 +2348,7 @@ msgid "Project Location"
 msgstr "Mahali pa mradi"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Fomu ya Dodoso"
 
@@ -2338,39 +2382,39 @@ msgstr ""
 "picha na video, ingia kwenye ODK Central na uzipakie kwenye mipangilio ya"
 " fomu."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Tayari kwa uchoraji ramani"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Inapakia msimbo wa QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Inapakia fomu ya mshirika..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Usanidi wa mradi"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Usanidi wa mradi"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI ya mradi"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Hatua ya 3: Pata data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Gawanya AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Kamilisha mradi"
 
@@ -2424,7 +2468,7 @@ msgstr "polilaini"
 msgid "points"
 msgstr "nukta"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "vipengele"
@@ -2460,7 +2504,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Inapakua..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Pakua data ya OSM"
@@ -2477,7 +2521,7 @@ msgstr "Gawanya kwa mraba"
 msgid "Split by buildings"
 msgstr "Gawanya kwa majengo"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Gawanya tena"
@@ -2571,6 +2615,129 @@ msgstr "Inaunda mradi katika %(project_type)s... Hii inaweza kuchukua muda kidog
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Hitilafu:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2765,7 +2932,14 @@ msgstr ""
 "Akaunti ya meneja haikuweza kuundwa kiotomatiki. Ingia kwenye QFieldCloud"
 " kama msimamizi ili kusimamia mradi."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Kubali machaguo ya kazi"
 
@@ -2894,95 +3068,104 @@ msgstr ""
 "anza na ramani tupu ili wachoraji ramani wakusanye kila kitu kuanzia "
 "mwanzo."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Anza na ramani tupu"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Pakia GeoJSON maalum"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Chaguo-msingi yanayopendekezwa yanafanya kazi kwa mradi huu."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Cha kupakua"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Majengo ya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Barabara za OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Huduma za afya za OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Vyoo vya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Kidini cha OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Matumizi ya ardhi ya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Njia za maji za OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Vyanzo vya maji vya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Utupaji taka wa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Elimu ya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Makaburi ya OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Huduma za OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "vipengele"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligoni"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilaini"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Nukta"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Tumia centrodi (Kwa upakuaji wa data ya OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Badilisha poligoni kuwa pointi moja moja."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Inazalisha dondoo la data ya OSM... Hii inaweza kuchukua muda kidogo."
 
@@ -3015,11 +3198,21 @@ msgstr ""
 "kufanya kazi sambamba. Chagua jinsi ya kugawanya hapa chini, hakiki "
 "matokeo, kisha yakubali. Au ruka kutumia eneo lote kama kazi moja."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Inagawanya..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3028,79 +3221,79 @@ msgstr ""
 "Unapogawanya kwa idadi ya majengo, vipengele hivi vya mstari hutumiwa "
 "kama mipaka ya asili ya kazi."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Jumuisha barabara"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Jumuisha mito"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Jumuisha reli"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Jumuisha njia za ndege"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Jinsi ya kugawanya"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Chagua mbinu..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Kwa idadi ya majengo (haraka zaidi)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Kwa idadi ya majengo (maumbo safi zaidi)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Kwa gridi ya kawaida"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Gawanya kwa idadi maalum ya kazi (inakuja hivi karibuni)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Wastani wa majengo kwa kazi:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Idadi ya kazi:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Ukubwa wa mraba wa gridi (mita)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Gawanya tena"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Inagawanya AOI katika kazi... Hii inaweza kuchukua muda kidogo."
 

--- a/src/backend/app/locales/ta/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ta/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: ta\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s தோல்வியடைந்தது."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API ஆனது HTTP %(status_code)sஐ வழங்கியது."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML படிவத்தை XLSForm ஆக மாற்ற முடியவில்லை."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "செல்லுபடியாகும் .xls அல்லது .xlsx கோப்பை வழங்கவும்"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "செல்லுபடியாகும் .xls அல்லது .xlsx கோப்பை வழங்கவும்"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "செல்லுபடியாகும் .xls அல்லது .xlsx கோப்பை வழங்கவும்"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-api இல் உள்நுழைய முடியவில்லை"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "வடிவவியல் இல்லை"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "உங்கள் geojson கோப்பு தவறானது."
 
@@ -263,44 +263,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR குறியீட்டை உருவாக்கும் போது எதிர்பாராத பிழை ஏற்பட்டது."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "திட்டம் (%(project_id)s) கிடைக்கவில்லை."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "இந்த திட்டத்தை திட்ட மேலாளர் மட்டுமே நீக்க முடியும்."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "திட்டம் கிடைக்கவில்லை."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "பிழை: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "திட்ட ஆசிரியர்களாக பின்வரும் பயனர்(கள்) சேர்க்கப்பட்டனர்: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' ஐச் சேர்க்க முடியவில்லை: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "மேலும் கூட்டுப்பணியாளர்களைச் சேர்க்கவும்"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud கூட்டுப்பணியாளர்களை அழைக்கவும்"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -308,7 +308,7 @@ msgstr ""
 "இந்த திட்டத்திற்கான அணுகலை வழங்குவதற்கு முன், மேப்பர்களுக்கு QFieldCloud "
 "இல் கணக்கு இருக்க வேண்டும்."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -318,7 +318,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> இல் இலவச "
 "கணக்கை உருவாக்க வேண்டும்."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -329,23 +329,23 @@ msgstr ""
 "அவர்கள் எடிட்டர்களாகச் சேர்க்கப்படுவார்கள் மற்றும் மேப்பிங்கைத் தொடங்க "
 "QField இல் உள்நுழையலாம்."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "எ.கா. ஆலிஸ், பாப், சார்லி"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "கூட்டுப்பணியாளர்களைச் சேர்க்கவும்"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "குறைந்தது ஒரு QFieldCloud பயனர்பெயரை உள்ளிடவும்."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "இந்த திட்டத்திற்கான QFieldCloud திட்ட ஐடி இல்லை."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -354,18 +354,42 @@ msgstr ""
 "கூட்டுப்பணியாளர்களை நிர்வகிக்க QFieldCloud நிர்வாகம் தாவலைப் "
 "பயன்படுத்தவும்."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON ஏற்றுமதி QField திட்டங்களுக்கு மட்டுமே கிடைக்கும்."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "இந்தத் திட்டம் இன்னும் QFieldCloud திட்டத்துடன் இணைக்கப்படவில்லை."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON ஐ ஏற்றுமதி செய்ய முடியவில்லை: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "திட்டம் கிடைக்கவில்லை அல்லது அணுகல் மறுக்கப்பட்டது."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -414,11 +438,6 @@ msgid ""
 msgstr ""
 "இந்த வெளியீட்டில் QField அடிப்படை வரைபட இணைப்பு அமைக்கப்படவில்லை. "
 "%(config)s இல்லை."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "திட்டம் கிடைக்கவில்லை அல்லது அணுகல் மறுக்கப்பட்டது."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -743,7 +762,7 @@ msgstr ""
 "பதிவிறக்கவும் அல்லது GeoJSON கோப்பை பதிவேற்றவும்."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "திட்ட AOI"
 
@@ -818,25 +837,25 @@ msgstr ""
 "ODK URL, பயனர் பெயர், கடவுச்சொல் (மூன்றும்) வழங்கவும்; அல்லது சேவையக "
 "இயல்புநிலைகளைப் பயன்படுத்த அனைத்தையும் காலியாக விடவும்."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "தரவு எடுக்கப்பட்டது (%(data_feature_count)s அம்சங்கள்)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "பணி எல்லைகள் (%(task_count)s பணிகள்)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "பணி அடையாளம்"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "கட்டிடங்களின் எண்ணிக்கை"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -844,7 +863,7 @@ msgstr ""
 "பணி எல்லைகள் எதுவும் கிடைக்கவில்லை. தயவுசெய்து மேலுள்ள \"Split AOI\" "
 "பொத்தானைப் பயன்படுத்தி முதலில் திட்டத்தைப் பணிகளாகப் பிரிக்கவும்."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -853,7 +872,7 @@ msgstr ""
 "✓ AOI வெற்றிகரமாகப் பிரிக்கப்பட்டது! %(algorithm)s பயன்படுத்தி "
 "%(task_count)s பணி பகுதிகள் உருவாக்கப்பட்டன."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -946,29 +965,29 @@ msgstr "பணி பகுதி தரவு வடிவம் தவறா�
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ பிரிக்கப்பட்ட பணிகள் வெற்றிகரமாகச் சேமிக்கப்பட்டன"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -977,7 +996,7 @@ msgstr ""
 "பரப்பு %(area_km2)s km² ஆகும்; இது %(area_limit)s km² வரம்பை மீறுகிறது. "
 "உங்கள் திட்டப் பரப்பை குறைக்கவும்."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -986,49 +1005,49 @@ msgstr ""
 "பரப்பு %(area_km2)s km² ஆகும். பெரிய பகுதிகள் (>%(area_warn)s km²) "
 "செயலாக்க அதிக நேரம் எடுக்கலாம்."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON அவசியம்"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "எந்த புற்களவும் கிடைக்கவில்லை. திட்ட பகுதி ஒரு புற்கோணமாக இருக்க வேண்டும்."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "தேர்ந்தெடுக்கப்பட்ட பகுதி மிகப் பெரியது. 200 km² ஐ விட சிறிய பகுதியைத் "
 "தேர்ந்தெடுக்கவும்."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "மூல தரவு API இலிருந்து தரவு சாற்றை உருவாக்க முடியவில்லை."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "திட்டம் கிடைக்கவில்லை."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "திட்டம் கிடைக்கவில்லை."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "திட்டம் கிடைக்கவில்லை."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "திட்டம் கிடைக்கவில்லை."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "மாதிரி படிவத்தை ஏற்ற முடியவில்லை."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1037,25 +1056,50 @@ msgstr ""
 "உருவாக்கப்பட்டது, மேலும் OpenStreetMap-ஐ மேம்படுத்த கட்டிடத் தரவைச் "
 "சேகரிக்க உருவாக்கப்பட்டது."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "பெயரில்லா பகுதி"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "பகுதி {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "திட்ட அவுட்லைன் காணவில்லை அல்லது வடிவியல் இல்லை."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "திட்ட அவுட்லைன் வடிவவியலுக்கு ஆயங்கள் இல்லை."
 
@@ -2213,8 +2257,8 @@ msgstr "அழி"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "படிவ விருப்பங்கள்:"
 
@@ -2236,7 +2280,7 @@ msgstr "தனிப்பயன் GeoJSON பதிவேற்று"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "அல்லது"
 
@@ -2321,7 +2365,7 @@ msgid "Project Location"
 msgstr "திட்ட இடம்"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "கணக்கெடுப்பு படிவம்"
 
@@ -2355,39 +2399,39 @@ msgstr ""
 "பதிவேற்ற வேண்டுமெனில், ODK Central இல் உள்நுழைந்து படிவ அமைப்புகளில் "
 "அவற்றை பதிவேற்றவும்."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "வரைபடத்திற்குத் தயாராக உள்ளது"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR குறியீடு ஏற்றப்படுகிறது..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "கூட்டுப்பணியாளர் படிவத்தை ஏற்றுகிறது..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "திட்ட அமைப்பு"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "திட்ட அமைப்பு"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "திட்ட AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "படி 3: தரவைப் பெறுக"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI ஐப் பிரி"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "திட்டத்தை இறுதிப்படுத்து"
 
@@ -2445,7 +2489,7 @@ msgstr "பாலிலைன்கள்"
 msgid "points"
 msgstr "புள்ளிகள்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "அம்சங்கள்"
@@ -2481,7 +2525,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "பதிவிறக்கப்படுகிறது..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM தரவை பதிவிறக்கு"
@@ -2498,7 +2542,7 @@ msgstr "சதுரப்படி பிரி"
 msgid "Split by buildings"
 msgstr "கட்டிடங்களின்படி பிரி"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "மீண்டும் பிரி"
@@ -2593,6 +2637,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "பிழை:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2789,7 +2956,14 @@ msgstr ""
 "மேலாளர் கணக்கை தானாக உருவாக்க முடியவில்லை. திட்டத்தை நிர்வகிக்க "
 "QFieldCloud இல் நிர்வாகியாக உள்நுழைக."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "பணி தேர்வுகளை ஏற்கவும்"
 
@@ -2919,95 +3093,104 @@ msgstr ""
 "எடுக்கவும், அல்லது வரைபடமிடுபவர்கள் அனைத்தையும் தொடக்கத்திலிருந்து "
 "சேகரிக்க காலி வரைபடத்துடன் தொடங்கவும்."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "காலி வரைபடத்துடன் தொடங்குங்கள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "தனிப்பயன் GeoJSON பதிவேற்று"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "இந்த திட்டத்திற்கு பரிந்துரைக்கப்பட்ட இயல்புநிலைகள் செயலில் உள்ளன."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "எதைப் பதிவிறக்க வேண்டும்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM கட்டிடங்கள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM சாலைகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM சுகாதாரம்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM கழிப்பறைகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM மதத்துறை"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM நிலப்பயன்பாடு"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM நீர்வழிகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM நீர்புள்ளிகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM கழிவுப்பொருள் அகற்றம்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM கல்வி"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM கல்லறைகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM வசதிகள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "அம்சங்கள்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "பலகோணம்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "பாலியிலைன்"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "புள்ளி"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "மையப் புள்ளிகளைப் பயன்படுத்து (OSM தரவைப் பதிவிறக்க)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "பல்கோணங்களை தனி புள்ளிகளாக மாற்றவும்."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM தரவு எடுப்பு உருவாக்கப்படுகிறது... இது சிறிது நேரம் எடுக்கலாம்."
 
@@ -3041,11 +3224,21 @@ msgstr ""
 "முடிவை முன்னோட்டமிட்டு ஏற்கவும். அல்லது முழுப் பகுதியையும் ஒரு பணியாகப் "
 "பயன்படுத்த தவிர்க்கவும்."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "பிரிக்கப்படுகிறது..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3054,79 +3247,79 @@ msgstr ""
 "கட்டிட எண்ணிக்கையால் பிரிக்கும் போது, இந்த கோடு அம்சங்கள் இயற்கையான பணி "
 "எல்லைகளாகப் பயன்படுத்தப்படுகின்றன."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "சாலைகளைச் சேர்க்கவும்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "நதிகளைச் சேர்க்கவும்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "ரயில்பாதைகளைச் சேர்க்கவும்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "விமானப் பாதைகளைச் சேர்க்கவும்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "எப்படி பிரிப்பது"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "முறையைத் தேர்ந்தெடுக்கவும்..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "கட்டிட எண்ணிக்கையால் (வேகமானது)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "கட்டிட எண்ணிக்கையால் (சுத்தமான வடிவங்கள்)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "வழக்கமான கட்டத்தால்"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "குறிப்பிட்ட பணிகளின் எண்ணிக்கைப்படி பிரி (விரைவில்)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "ஒரு பணிக்கு சராசரி கட்டிடங்கள்:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "பணிகளின் எண்ணிக்கை:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "கட்ட சதுர அளவு (மீட்டர்)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "மீண்டும் பிரி"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI பணிகளாகப் பிரிக்கப்படுகிறது... இது சிறிது நேரம் எடுக்கலாம்."
 

--- a/src/backend/app/locales/te/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/te/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: te\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s విఫలమైంది."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API HTTP %(status_code)sని అందించింది."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML ఫారమ్‌ని XLSFormకి మార్చడంలో విఫలమైంది."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "చెల్లుబాటు అయ్యే .xls లేదా .xlsx ఫైల్‌ను ఇవ్వండి"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "చెల్లుబాటు అయ్యే .xls లేదా .xlsx ఫైల్‌ను ఇవ్వండి"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "చెల్లుబాటు అయ్యే .xls లేదా .xlsx ఫైల్‌ను ఇవ్వండి"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-apiకి లాగిన్ చేయడం సాధ్యపడలేదు"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "జ్యామితులు లేవు"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "మీ geojson ఫైల్ చెల్లదు."
 
@@ -261,44 +261,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR కోడ్‌ను రూపొందిస్తున్నప్పుడు అనూహ్యమైన లోపం ఏర్పడింది."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "ప్రాజెక్ట్ (%(project_id)s) కనబడలేదు."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "ఈ ప్రాజెక్ట్‌ను ప్రాజెక్ట్ మేనేజర్ మాత్రమే తొలగించగలరు."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "ప్రాజెక్ట్ కనబడలేదు."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "లోపం: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "కింది వినియోగదారు(లు) ప్రాజెక్ట్ ఎడిటర్‌లుగా జోడించబడ్డారు: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s'ని జోడించడం సాధ్యపడలేదు: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "మరింత మంది సహకారులను జోడించండి"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud సహకారులను ఆహ్వానించండి"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -306,7 +306,7 @@ msgstr ""
 "మీరు ఈ ప్రాజెక్ట్‌కి యాక్సెస్ ఇవ్వడానికి ముందు మ్యాపర్‌లు తప్పనిసరిగా "
 "QFieldCloudలో ఖాతాను కలిగి ఉండాలి."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -316,7 +316,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a>లో ఉచిత "
 "ఖాతాను సృష్టించేలా చేయండి."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -327,23 +327,23 @@ msgstr ""
 "వారు సంపాదకులుగా జోడించబడతారు మరియు మ్యాపింగ్ ప్రారంభించడానికి QFieldకి "
 "లాగిన్ చేయవచ్చు."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "ఉదా ఆలిస్, బాబ్, చార్లీ"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "సహకారులను జోడించండి"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "కనీసం ఒక QFieldCloud వినియోగదారు పేరును నమోదు చేయండి."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ఈ ప్రాజెక్ట్ కోసం QFieldCloud ప్రాజెక్ట్ ID కనుగొనబడలేదు."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -351,18 +351,42 @@ msgstr ""
 "ఈ ప్రాజెక్ట్ అనుకూల QFieldCloud ఉదాహరణలో సృష్టించబడింది. సహకారులను "
 "నిర్వహించడానికి QFieldCloud అడ్మిన్ ట్యాబ్‌ని ఉపయోగించండి."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON ఎగుమతి QField ప్రాజెక్ట్‌లకు మాత్రమే అందుబాటులో ఉంది."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "ఈ ప్రాజెక్ట్ ఇంకా QFieldCloud ప్రాజెక్ట్‌కి లింక్ చేయబడలేదు."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSONని ఎగుమతి చేయడంలో విఫలమైంది: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "ప్రాజెక్ట్ కనబడలేదు లేదా ప్రాప్తి నిరాకరించబడింది."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -409,11 +433,6 @@ msgid ""
 msgstr ""
 "ఈ డిప్లాయ్‌మెంట్‌లో QField బేస్‌మ్యాప్ జతచేయడం కాన్ఫిగర్ చేయలేదు. "
 "%(config)s లేదు."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "ప్రాజెక్ట్ కనబడలేదు లేదా ప్రాప్తి నిరాకరించబడింది."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -734,7 +753,7 @@ msgstr ""
 "GeoJSON ఫైల్‌ను అప్‌లోడ్ చేయండి."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "ప్రాజెక్ట్ AOI"
 
@@ -807,25 +826,25 @@ msgstr ""
 "ODK URL, వినియోగదారు పేరు, పాస్‌వర్డ్ (మూడింటినీ) ఇవ్వండి, లేదా సర్వర్ "
 "డిఫాల్ట్‌లను ఉపయోగించడానికి అన్నింటినీ ఖాళీగా వదిలేయండి."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "డేటా ఎక్స్‌ట్రాక్ట్ (%(data_feature_count)s లక్షణాలు)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "పని సరిహద్దులు (%(task_count)s పనులు)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "టాస్క్ ఐడి"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "భవనాల సంఖ్య"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -833,7 +852,7 @@ msgstr ""
 "పని సరిహద్దులు కనబడలేదు. దయచేసి ముందుగా పై ఉన్న \"Split AOI\" బటన్ "
 "ఉపయోగించి ప్రాజెక్ట్‌ను పనులుగా విభజించండి."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -842,7 +861,7 @@ msgstr ""
 "✓ AOI విజయవంతంగా విభజించబడింది! %(algorithm)s ఉపయోగించి %(task_count)s "
 "పని ప్రాంతాలు రూపొందించబడ్డాయి."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -933,29 +952,29 @@ msgstr "చెల్లని పని ప్రాంతాల డేటా �
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ విభజించిన పనులు విజయవంతంగా సేవ్ అయ్యాయి"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -964,7 +983,7 @@ msgstr ""
 "ప్రాంతం %(area_km2)s km² ఉంది, ఇది %(area_limit)s km² పరిమితిని "
 "మించుతోంది. దయచేసి మీ ప్రాజెక్ట్ ప్రాంతాన్ని తగ్గించండి."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -973,49 +992,49 @@ msgstr ""
 "ప్రాంతం %(area_km2)s km² ఉంది. పెద్ద ప్రాంతాలు (>%(area_warn)s km²) "
 "ప్రాసెస్ చేయడానికి ఎక్కువ సమయం పట్టవచ్చు."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON అవసరం"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "పాలిగాన్ జ్యామితులు కనబడలేదు. ప్రాజెక్ట్ ప్రాంతం ఒక పాలిగాన్ అయి ఉండాలి."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "ఎంచుకున్న ప్రాంతం చాలా పెద్దది. దయచేసి 200 km² కంటే చిన్న ప్రాంతాన్ని "
 "ఎంచుకోండి."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "ముడి డేటా API నుండి డేటా సారాన్ని రూపొందించడంలో విఫలమైంది."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "ప్రాజెక్ట్ కనబడలేదు."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "ప్రాజెక్ట్ కనబడలేదు."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "ప్రాజెక్ట్ కనబడలేదు."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "ప్రాజెక్ట్ కనబడలేదు."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "టెంప్లేట్ ఫారమ్‌ను లోడ్ చేయలేకపోయాము."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1024,25 +1043,50 @@ msgstr ""
 "OpenStreetMap ను మెరుగుపరచడానికి భవనాల డేటా సేకరించడానికి "
 "రూపొందించబడింది."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "పేరు లేని ప్రాంతం"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "ప్రాంతం {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "ప్రాజెక్ట్ అవుట్‌లైన్ లేదు లేదా జ్యామితి లేదు."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "ప్రాజెక్ట్ అవుట్‌లైన్ జ్యామితికి కోఆర్డినేట్‌లు లేవు."
 
@@ -2193,8 +2237,8 @@ msgstr "తొలగించు"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "ఫారమ్ ఎంపికలు:"
 
@@ -2216,7 +2260,7 @@ msgstr "కస్టమ్ GeoJSON అప్‌లోడ్ చేయండి"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "లేదా"
 
@@ -2301,7 +2345,7 @@ msgid "Project Location"
 msgstr "ప్రాజెక్ట్ స్థానం"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "సర్వే ఫారమ్"
 
@@ -2335,39 +2379,39 @@ msgstr ""
 "చేయాల్సి ఉంటే, ODK Central లో లాగిన్ అయి ఫారమ్ సెట్టింగ్‌లలో అప్‌లోడ్ "
 "చేయండి."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "మ్యాపింగ్‌కు సిద్ధం"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR కోడ్ లోడ్ అవుతోంది..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "సహకారి ఫారమ్ లోడ్ అవుతోంది..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "ప్రాజెక్ట్ సెటప్"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "ప్రాజెక్ట్ సెటప్"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "ప్రాజెక్ట్ AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "దశ 3: డేటాను పొందండి"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI ని విభజించు"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "ప్రాజెక్ట్‌ను పూర్తిచేయండి"
 
@@ -2419,7 +2463,7 @@ msgstr "పాలీలైన్లు"
 msgid "points"
 msgstr "బిందువులు"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "లక్షణాలు"
@@ -2455,7 +2499,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "డౌన్‌లోడ్ అవుతోంది..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM డేటాను డౌన్‌లోడ్ చేయండి"
@@ -2472,7 +2516,7 @@ msgstr "చదరంగా విభజించు"
 msgid "Split by buildings"
 msgstr "భవనాల ప్రకారం విభజించు"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "మళ్లీ విభజించు"
@@ -2567,6 +2611,129 @@ msgstr "%(project_type)s లో ప్రాజెక్ట్ రూపొం�
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "లోపం:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2762,7 +2929,14 @@ msgstr ""
 "మేనేజర్ ఖాతా స్వయంచాలకంగా సృష్టించబడలేదు. ప్రాజెక్ట్‌ను నిర్వహించడానికి "
 "QFieldCloud లో admin గా లాగిన్ అవ్వండి."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "పని ఎంపికలను అంగీకరించండి"
 
@@ -2891,95 +3065,104 @@ msgstr ""
 "లేదా మ్యాపర్లు అన్నీ మొదటి నుంచి సేకరించేందుకు ఖాళీ మ్యాప్‌తో "
 "ప్రారంభించండి."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "ఖాళీ మ్యాప్‌తో ప్రారంభించండి"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "కస్టమ్ GeoJSON అప్‌లోడ్ చేయండి"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "ఈ ప్రాజెక్ట్‌కు సిఫార్సు చేసిన డిఫాల్ట్‌లు సక్రియంగా ఉన్నాయి."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "ఏమి డౌన్‌లోడ్ చేయాలి"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM భవనాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM రహదారులు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM ఆరోగ్య సేవలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM మరుగుదొడ్లు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM మత సంబంధిత"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM భూ వినియోగం"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM జలమార్గాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM నీటి కేంద్రాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM వ్యర్థాల నిర్వాహణ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM విద్య"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM సమాధి స్థలాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM సౌకర్యాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "లక్షణాలు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "బహుభుజం"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "పాలీలైన్"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "బిందువు"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "కేంద్ర బిందువులను ఉపయోగించండి (OSM డేటా డౌన్‌లోడ్ కోసం)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "బహుభుజాలను ఒక్కో పాయింట్లుగా మార్చండి."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM డేటా ఎక్స్‌ట్రాక్ట్ రూపొందుతోంది... దీనికి కొంత సమయం పట్టవచ్చు."
 
@@ -3013,11 +3196,21 @@ msgstr ""
 "తర్వాత అంగీకరించండి. లేదా మొత్తం ప్రాంతాన్ని ఒకే పనిగా ఉపయోగించడానికి "
 "దాటవేయండి."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "విభజిస్తోంది..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3026,79 +3219,79 @@ msgstr ""
 "భవనాల సంఖ్య ఆధారంగా విభజించేటప్పుడు, ఈ రేఖీయ ఫీచర్లు సహజ పనుల "
 "సరిహద్దులుగా ఉపయోగించబడతాయి."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "రహదారులను చేర్చండి"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "నదులను చేర్చండి"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "రైలుమార్గాలను చేర్చండి"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "విమాన మార్గాలను చేర్చండి"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "ఎలా విభజించాలి"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "ఒక పద్ధతి ఎంచుకోండి..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "భవనాల సంఖ్య ప్రకారం (వేగంగా)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "భవనాల సంఖ్య ప్రకారం (శుభ్రమైన ఆకారాలు)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "నియమిత గ్రిడ్ ప్రకారం"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "నిర్దిష్ట పనుల సంఖ్య ప్రకారం విభజించు (త్వరలో)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "ఒక పనికి సగటు భవనాలు:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "పనుల సంఖ్య:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "గ్రిడ్ చతురస్ర పరిమాణం (మీటర్లు)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "మళ్లీ విభజించు"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI ను పనులుగా విభజిస్తోంది... దీనికి కొంత సమయం పట్టవచ్చు."
 

--- a/src/backend/app/locales/th/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/th/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: th\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s ล้มเหลวเนื่องจากข้อผ�
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API ส่งคืน HTTP %(status_code)s"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "ไม่สามารถแปลงแบบฟอร์ม YAML เป็น XLSForm"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "โปรดระบุไฟล์ .xls หรือ .xlsx ที่ถูกต้อง"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "โปรดระบุไฟล์ .xls หรือ .xlsx ที่ถูกต้อง"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "โปรดระบุไฟล์ .xls หรือ .xlsx ที่ถูกต้อง"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "ไม่สามารถเข้าสู่ระบบ raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "ไม่มีรูปทรงเรขาคณิต"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "ไฟล์ geojson ของคุณไม่ถูกต้อง"
 
@@ -258,44 +258,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "เกิดข้อผิดพลาดที่ไม่คาดคิดขณะสร้างรหัส QR"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "ไม่พบโครงการ (%(project_id)s)"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "มีเพียงผู้จัดการโครงการเท่านั้นที่ลบโครงการนี้ได้"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "ไม่พบโครงการ"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "ข้อผิดพลาด: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "เพิ่มผู้ใช้ต่อไปนี้เป็นผู้แก้ไขโครงการ: %(names)s"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "ไม่สามารถเพิ่ม '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "เพิ่มผู้ทำงานร่วมกันเพิ่มเติม"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "เชิญผู้ทำงานร่วมกันของ QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -303,7 +303,7 @@ msgstr ""
 "ผู้ทำแผนที่ต้องมีบัญชีบน QFieldCloud "
 "ก่อนจึงจะสามารถให้สิทธิ์พวกเขาในการเข้าถึงโปรเจ็กต์นี้ได้"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -313,7 +313,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -324,23 +324,23 @@ msgstr ""
 "พวกเขาจะถูกเพิ่มเป็นผู้แก้ไขและสามารถเข้าสู่ระบบ QField "
 "เพื่อเริ่มการทำแผนที่ได้"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "เช่น อลิซ, บ๊อบ, ชาร์ลี"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "เพิ่มผู้ทำงานร่วมกัน"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "ป้อนชื่อผู้ใช้ QFieldCloud อย่างน้อยหนึ่งรายการ"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ไม่พบรหัสโปรเจ็กต์ QFieldCloud สำหรับโปรเจ็กต์นี้"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -348,18 +348,42 @@ msgstr ""
 "โปรเจ็กต์นี้สร้างขึ้นบนอินสแตนซ์ QFieldCloud ที่กำหนดเอง "
 "ใช้แท็บผู้ดูแลระบบ QFieldCloud เพื่อจัดการผู้ทำงานร่วมกัน"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "การส่งออก GeoJSON ใช้ได้กับโปรเจ็กต์ QField เท่านั้น"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "โปรเจ็กต์นี้ยังไม่ได้เชื่อมโยงกับโปรเจ็กต์ QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "ไม่สามารถส่งออก GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "ไม่พบโครงการหรือถูกปฏิเสธการเข้าถึง"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -403,11 +427,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "ยังไม่ได้ตั้งค่าการแนบแผนที่ฐานของ QField ในการติดตั้งนี้ ขาด %(config)s"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "ไม่พบโครงการหรือถูกปฏิเสธการเข้าถึง"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -714,7 +733,7 @@ msgid ""
 msgstr "ไม่พบข้อมูล GeoJSON โปรดดาวน์โหลดข้อมูล OSM หรืออัปโหลดไฟล์ GeoJSON ก่อน"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI ของโครงการ"
 
@@ -787,31 +806,31 @@ msgstr ""
 "ระบุ ODK URL ชื่อผู้ใช้ และรหัสผ่าน (ทั้ง 3 รายการ) "
 "หรือเว้นว่างทั้งหมดเพื่อใช้ค่าเริ่มต้นของเซิร์ฟเวอร์"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "ข้อมูลที่ดึงออก (%(data_feature_count)s ฟีเจอร์)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "ขอบเขตงาน (%(task_count)s งาน)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "รหัสงาน"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "จำนวนอาคาร"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
 msgstr "ไม่พบขอบเขตงาน โปรดแบ่งโครงการเป็นงานก่อนโดยใช้ปุ่ม \"Split AOI\" ด้านบน"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -820,7 +839,7 @@ msgstr ""
 "✓ แบ่ง AOI สำเร็จแล้ว สร้างพื้นที่งาน %(task_count)s พื้นที่โดยใช้ "
 "%(algorithm)s"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -908,29 +927,29 @@ msgstr "รูปแบบข้อมูลพื้นที่งานไม
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ บันทึกการแบ่งงานสำเร็จ"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -939,7 +958,7 @@ msgstr ""
 "พื้นที่คือ %(area_km2)s km² ซึ่งเกินขีดจำกัด %(area_limit)s km² "
 "โปรดลดพื้นที่โปรเจกต์ของคุณ"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -948,47 +967,47 @@ msgstr ""
 "พื้นที่คือ %(area_km2)s km² พื้นที่ขนาดใหญ่ (>%(area_warn)s km²) "
 "อาจใช้เวลาประมวลผลนานขึ้น"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "จำเป็นต้องมี GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "ไม่พบรูปทรงแบบหลายเหลี่ยม พื้นที่โครงการต้องเป็นรูปหลายเหลี่ยม"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "พื้นที่ที่เลือกใหญ่เกินไป โปรดเลือกพื้นที่ที่เล็กกว่า 200 km²"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "ไม่สามารถสร้างการแยกข้อมูลจาก API ข้อมูลดิบ"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "ไม่พบโครงการ"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "ไม่พบโครงการ"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "ไม่พบโครงการ"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "ไม่พบโครงการ"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "โหลดแบบฟอร์มแม่แบบไม่สำเร็จ"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -996,25 +1015,50 @@ msgstr ""
 "โครงการนี้ถูกสร้างด้วยเวิร์กโฟลว์แบบง่ายใน FieldTM "
 "และออกแบบมาเพื่อเก็บข้อมูลอาคารเพื่อปรับปรุง OpenStreetMap"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "พื้นที่ไม่มีชื่อ"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "พื้นที่ {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "ขาดหายไปหรือไม่มีรูปทรงเรขาคณิต"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "เรขาคณิตโครงร่างของโครงการไม่มีพิกัด"
 
@@ -2123,8 +2167,8 @@ msgstr "ล้าง"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "ตัวเลือกแบบฟอร์ม:"
 
@@ -2146,7 +2190,7 @@ msgstr "อัปโหลด GeoJSON แบบกำหนดเอง"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "หรือ"
 
@@ -2225,7 +2269,7 @@ msgid "Project Location"
 msgstr "ตำแหน่งโครงการ"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "แบบฟอร์มสำรวจ"
 
@@ -2258,39 +2302,39 @@ msgstr ""
 "หากคุณต้องการอัปโหลดไฟล์สื่อเพิ่มเติมไปยังโครงการนี้ เช่น รูปภาพและวิดีโอ"
 " ให้เข้าสู่ระบบ ODK Central และอัปโหลดในส่วนการตั้งค่าแบบฟอร์ม"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "พร้อมสำหรับการทำแผนที่"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "กำลังโหลดรหัส QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "กำลังโหลดแบบฟอร์มผู้ทำงานร่วมกัน..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "การตั้งค่าโครงการ"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "การตั้งค่าโครงการ"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI ของโครงการ"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "ขั้นตอนที่ 3: รับข้อมูล"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "แบ่ง AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "ปิดงานโครงการ"
 
@@ -2342,7 +2386,7 @@ msgstr "เส้นหลายช่วง"
 msgid "points"
 msgstr "จุด"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "ฟีเจอร์"
@@ -2378,7 +2422,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "กำลังดาวน์โหลด..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "ดาวน์โหลดข้อมูล OSM"
@@ -2395,7 +2439,7 @@ msgstr "แบ่งตามสี่เหลี่ยม"
 msgid "Split by buildings"
 msgstr "แบ่งตามอาคาร"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "แบ่งอีกครั้ง"
@@ -2488,6 +2532,129 @@ msgstr "กำลังสร้างโครงการใน %(project_type
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "ข้อผิดพลาด:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2679,7 +2846,14 @@ msgstr ""
 "ไม่สามารถสร้างบัญชีผู้จัดการโดยอัตโนมัติได้ โปรดเข้าสู่ระบบ QFieldCloud "
 "ในฐานะผู้ดูแลเพื่อจัดการโครงการ"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "ยอมรับตัวเลือกงาน"
 
@@ -2803,95 +2977,104 @@ msgstr ""
 "ดึงฟีเจอร์ที่มีอยู่จาก OpenStreetMap สำหรับพื้นที่โครงการของคุณ "
 "หรือเริ่มด้วยแผนที่ว่างเพื่อให้ผู้ทำแผนที่เก็บข้อมูลทุกอย่างตั้งแต่ต้น"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "เริ่มด้วยแผนที่ว่าง"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "อัปโหลด GeoJSON แบบกำหนดเอง"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "ค่าเริ่มต้นที่แนะนำถูกเปิดใช้งานสำหรับโครงการนี้"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "สิ่งที่จะดาวน์โหลด"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "อาคาร OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "ทางหลวง OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "สถานพยาบาล OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "ห้องน้ำ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "ศาสนสถาน OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "การใช้ที่ดิน OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "ทางน้ำ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "จุดน้ำ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "จุดกำจัดขยะ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "การศึกษา OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "สุสาน OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "สิ่งอำนวยความสะดวก OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "ฟีเจอร์"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "รูปหลายเหลี่ยม"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "เส้นหลายช่วง"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "จุด"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "ใช้จุดกึ่งกลาง (สำหรับการดาวน์โหลดข้อมูล OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "แปลงโพลีกอนเป็นจุดเดี่ยว"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "กำลังสร้างข้อมูลที่ดึงออกจาก OSM... อาจใช้เวลาสักครู่"
 
@@ -2924,11 +3107,21 @@ msgstr ""
 "เลือกวิธีแบ่งด้านล่าง ดูตัวอย่างผลลัพธ์ แล้วจึงยอมรับ "
 "หรือข้ามเพื่อใช้ทั้งพื้นที่เป็นงานเดียว"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "กำลังแบ่ง..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2937,79 +3130,79 @@ msgstr ""
 "เมื่อแบ่งตามจำนวนอาคาร "
 "ฟีเจอร์เชิงเส้นเหล่านี้จะใช้เป็นขอบเขตงานตามธรรมชาติ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "รวมถนน"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "รวมแม่น้ำ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "รวมทางรถไฟ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "รวมเส้นทางการบิน"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "วิธีแบ่ง"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "เลือกวิธี..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "ตามจำนวนอาคาร (เร็วกว่า)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "ตามจำนวนอาคาร (รูปทรงเรียบร้อยกว่า)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "ตามกริดปกติ"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "แบ่งตามจำนวนงานที่กำหนด (เร็ว ๆ นี้)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "จำนวนอาคารเฉลี่ยต่องาน:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "จำนวนงาน:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "ขนาดช่องกริด (เมตร)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "แบ่งอีกครั้ง"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "กำลังแบ่ง AOI เป็นงาน... อาจใช้เวลาสักครู่"
 

--- a/src/backend/app/locales/tl/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/tl/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: tl\n"
@@ -164,31 +164,31 @@ msgstr "%(action)s dahil sa error sa upstream na koneksyon."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API ay nagbalik ng HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Nabigong i-convert ang YAML form sa XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Magbigay ng wastong .xls o .xlsx file"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Magbigay ng wastong .xls o .xlsx file"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Magbigay ng wastong .xls o .xlsx file"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Hindi makapag-log in sa raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Walang mga geometries na naroroon"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Ang iyong geojson file ay hindi wasto."
 
@@ -269,48 +269,48 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "May nangyaring hindi inaasahang error habang ginagawa ang QR code."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Hindi nahanap ang proyekto (%(project_id)s)."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr ""
 "Tanging ang project manager lamang ang maaaring magtanggal sa proyektong "
 "ito."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Hindi nahanap ang proyekto."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Kamalian: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr ""
 "Idinagdag ang sumusunod na (mga) user bilang mga editor ng proyekto: "
 "%(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Hindi maidagdag ang '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Magdagdag pa ng mga collaborator"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Mag-imbita ng mga collaborator ng QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -318,7 +318,7 @@ msgstr ""
 "Dapat ay may account ang mga Mapper sa QFieldCloud bago mo sila mabigyan "
 "ng access sa proyektong ito."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -328,7 +328,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -339,23 +339,23 @@ msgstr ""
 "bilang mga editor at maaaring mag-log in sa QField upang simulan ang "
 "pagmamapa."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "hal. alice, bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Magdagdag ng mga collaborator"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Maglagay ng kahit isang QFieldCloud username."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Hindi nakita ang project ID ng QFieldCloud para sa proyektong ito."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -364,20 +364,44 @@ msgstr ""
 " Gamitin ang tab na QFieldCloud Admin para pamahalaan ang mga "
 "collaborator."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr ""
 "Ang pag-export ng GeoJSON ay magagamit lamang para sa mga proyekto ng "
 "QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Ang proyektong ito ay hindi pa naka-link sa isang proyekto ng QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Nabigong i-export ang GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Hindi nahanap ang proyekto o tinanggihan ang access."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -426,11 +450,6 @@ msgid ""
 msgstr ""
 "Hindi naka-configure ang pagdikit ng basemap ng QField sa deployment na "
 "ito. Nawawala ang %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Hindi nahanap ang proyekto o tinanggihan ang access."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -750,7 +769,7 @@ msgstr ""
 "upload muna ng GeoJSON file."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI ng Proyekto"
 
@@ -823,25 +842,25 @@ msgstr ""
 "Magbigay ng ODK URL, username, at password (lahat ng 3), o iwanang "
 "blangko ang lahat para gamitin ang default ng server."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Data Extract (%(data_feature_count)s feature)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Mga Hangganan ng Gawain (%(task_count)s gawain)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID ng Gawain"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Bilang ng Gusali"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -849,7 +868,7 @@ msgstr ""
 "Walang nahanap na hangganan ng gawain. Hatiin muna ang proyekto sa mga "
 "gawain gamit ang button na \"Split AOI\" sa itaas."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -858,7 +877,7 @@ msgstr ""
 "✓ Matagumpay na nahati ang AOI! Nakabuo ng %(task_count)s task area gamit"
 " ang %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -953,29 +972,29 @@ msgstr "Hindi wastong format ng data para sa task areas."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Matagumpay na na-save ang mga hinating gawain"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -984,7 +1003,7 @@ msgstr ""
 "Ang area ay %(area_km2)s km², na lumalampas sa limit na %(area_limit)s "
 "km². Pakibawasan ang area ng proyekto."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -993,49 +1012,49 @@ msgstr ""
 "Ang area ay %(area_km2)s km². Maaaring mas matagal iproseso ang "
 "malalaking area (>%(area_warn)s km²)."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Kinakailangan ang GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Walang nakitang polygon geometry. Ang lawak ng proyekto ay dapat polygon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr ""
 "Masyadong malaki ang napiling lugar. Mangyaring pumili ng lugar na mas "
 "maliit sa 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Nabigong bumuo ng data extract mula sa raw data API."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Hindi nahanap ang proyekto."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Hindi nahanap ang proyekto."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Hindi nahanap ang proyekto."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Hindi nahanap ang proyekto."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Hindi na-load ang template form."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1044,25 +1063,50 @@ msgstr ""
 "FieldTM at nakalaan ito para mangolekta ng datos ng mga gusali upang "
 "mapahusay ang OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Lugar na Walang Pangalan"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Lugar {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Project."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Project outline geometry ay walang mga coordinate."
 
@@ -2224,8 +2268,8 @@ msgstr "I-clear"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Mga opsyon sa form:"
 
@@ -2247,7 +2291,7 @@ msgstr "Mag-upload ng Custom GeoJSON"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "o"
 
@@ -2334,7 +2378,7 @@ msgid "Project Location"
 msgstr "Lokasyon ng Proyekto"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Form ng Survey"
 
@@ -2368,39 +2412,39 @@ msgstr ""
 "ito, gaya ng mga larawan at video, mag-log in sa ODK Central at i-upload "
 "ang mga ito sa form settings."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Handa para sa Mapping"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Nilo-load ang QR code..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Nilo-load ang form ng collaborator..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Setup ng Proyekto"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Setup ng Proyekto"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI ng Proyekto"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Hakbang 3: Kunin ang Data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Hatiin ang AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "I-finalize ang Proyekto"
 
@@ -2458,7 +2502,7 @@ msgstr "mga polyline"
 msgid "points"
 msgstr "mga punto"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "mga feature"
@@ -2494,7 +2538,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Nagda-download..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "I-download ang OSM Data"
@@ -2511,7 +2555,7 @@ msgstr "Hatiin ayon sa Parisukat"
 msgid "Split by buildings"
 msgstr "Hatiin ayon sa mga Gusali"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Hatiin Muli"
@@ -2606,6 +2650,129 @@ msgstr ""
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Kamalian:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2803,7 +2970,14 @@ msgstr ""
 "Hindi awtomatikong nalikha ang manager account. Mag-log in sa QFieldCloud"
 " bilang admin upang pamahalaan ang proyekto."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Tanggapin ang mga Piniling Gawain"
 
@@ -2933,95 +3107,104 @@ msgstr ""
 " proyekto mo, o magsimula sa walang laman na mapa para makolekta ng mga "
 "mapper ang lahat mula sa simula."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Magsimula sa walang laman na mapa"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Mag-upload ng Custom GeoJSON"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Aktibo ang mga inirerekomendang default para sa proyektong ito."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Ano ang ida-download"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Mga Gusali ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Mga Kalsada ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Pangkalusugang OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Mga Palikuran ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Panrelihiyong OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Paggamit ng Lupa sa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Mga Daluyan ng Tubig sa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Mga Water Point ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Pagtatapon ng Basura sa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Edukasyon sa OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Mga Sementeryo ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Mga Amenity ng OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "mga feature"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligono"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Poliyolina"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Punto"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Gumamit ng centroid (Para sa pag-download ng datos ng OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Gawing iisang mga punto ang mga polygon."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Binubuo ang OSM data extract... Maaaring tumagal ito nang kaunti."
 
@@ -3055,11 +3238,21 @@ msgstr ""
 "i-preview ang resulta, pagkatapos tanggapin ito. O laktawan para gamitin "
 "ang buong lugar bilang isang gawain."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Hinahati..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3068,79 +3261,79 @@ msgstr ""
 "Kapag hinahati ayon sa bilang ng gusali, ginagamit ang mga linear feature"
 " na ito bilang natural na hangganan ng gawain."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Isama ang mga kalsada"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Isama ang mga ilog"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Isama ang mga riles"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Isama ang mga daanang panghimpapawid"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Paano hatiin"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Pumili ng paraan..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Ayon sa bilang ng gusali (mas mabilis)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Ayon sa bilang ng gusali (mas malinis na hugis)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Ayon sa regular na grid"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Hatiin ayon sa Tiyak na Bilang ng Gawain (Malapit na)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Karaniwang Gusali bawat Gawain:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Bilang ng mga gawain:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Laki ng parisukat ng grid (metro)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Hatiin Muli"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Hinahati ang AOI sa mga gawain... Maaaring tumagal ito nang kaunti."
 

--- a/src/backend/app/locales/tr/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/tr/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: tr\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s, yukarı akış bağlantı hatası nedeniyle başarısız old
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API, HTTP %(status_code)s'i döndürdü."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML formu XLSForm'a dönüştürülemedi."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Geçerli bir .xls veya .xlsx dosyası sağlayın"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Geçerli bir .xls veya .xlsx dosyası sağlayın"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Geçerli bir .xls veya .xlsx dosyası sağlayın"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Ham veri API'sine giriş yapılamadı"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Geometri yok"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Geojson dosyanız geçersiz."
 
@@ -261,44 +261,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR kodu oluşturulurken beklenmeyen bir hata oluştu."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Proje (%(project_id)s) bulunamadı."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Bu projeyi yalnızca proje yöneticisi silebilir."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Proje bulunamadı."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Hata: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Şu kullanıcı(lar) proje düzenleyicileri olarak eklendi: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' eklenemedi: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Daha fazla ortak çalışan ekleyin"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud ortak çalışanlarını davet edin"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -306,7 +306,7 @@ msgstr ""
 "Haritacıların bu projeye erişmesine izin vermeden önce QFieldCloud'da bir"
 " hesaba sahip olmaları gerekir."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -316,7 +316,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> adresinde"
 " ücretsiz bir hesap oluşturmasını sağlayın."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -327,23 +327,23 @@ msgstr ""
 "eklenecekler ve haritalamayı başlatmak için QField'da oturum "
 "açabilecekler."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "örneğin alice, bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Ortak çalışan ekle"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "En az bir QFieldCloud kullanıcı adı girin."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Bu proje için QFieldCloud proje kimliği bulunamadı."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -351,18 +351,42 @@ msgstr ""
 "Bu proje özel bir QFieldCloud örneğinde oluşturuldu. Ortak çalışanları "
 "yönetmek için QFieldCloud Yönetici sekmesini kullanın."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON dışa aktarımı yalnızca QField projeleri için kullanılabilir."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Bu proje henüz bir QFieldCloud projesine bağlı değil."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON dışa aktarılamadı: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Proje bulunamadı veya erişim reddedildi."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -408,11 +432,6 @@ msgid ""
 msgstr ""
 "Bu dağıtımda QField altlık harita ekleme yapılandırılmamış. %(config)s "
 "eksik."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Proje bulunamadı veya erişim reddedildi."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -725,7 +744,7 @@ msgstr ""
 "GeoJSON dosyası yükleyin."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "Proje AOI"
 
@@ -798,25 +817,25 @@ msgstr ""
 "ODK URL, kullanıcı adı ve şifreyi (üçünü birden) sağlayın ya da sunucu "
 "varsayılanlarını kullanmak için hepsini boş bırakın."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Veri Çıkarımı (%(data_feature_count)s özellik)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Görev Sınırları (%(task_count)s görev)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "Görev Kimliği"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Bina Sayısı"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -824,7 +843,7 @@ msgstr ""
 "Görev sınırı bulunamadı. Lütfen önce yukarıdaki \"Split AOI\" düğmesini "
 "kullanarak projeyi görevlere ayırın."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -833,7 +852,7 @@ msgstr ""
 "✓ AOI başarıyla bölündü! %(algorithm)s kullanılarak %(task_count)s görev "
 "alanı oluşturuldu."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -924,29 +943,29 @@ msgstr "Geçersiz görev alanı veri biçimi."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Bölünmüş görevler başarıyla kaydedildi"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -955,7 +974,7 @@ msgstr ""
 "Alan %(area_km2)s km², bu da %(area_limit)s km² sınırını aşıyor. Lütfen "
 "proje alanınızı küçültün."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -964,47 +983,47 @@ msgstr ""
 "Alan %(area_km2)s km². Büyük alanların (>%(area_warn)s km²) işlenmesi "
 "daha uzun sürebilir."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON gereklidir"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Poligon geometrisi bulunamadı. Proje alanı bir poligon olmalıdır."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Seçilen alan çok büyük. Lütfen 200 km²'den küçük bir alan seçin."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Ham veri API'sinden veri özütü oluşturulamadı."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Proje bulunamadı."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Proje bulunamadı."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Proje bulunamadı."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Proje bulunamadı."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Şablon form yüklenemedi."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1012,25 +1031,50 @@ msgstr ""
 "Bu proje FieldTM içinde basitleştirilmiş bir iş akışıyla oluşturuldu ve "
 "OpenStreetMap’i geliştirmek için bina verisi toplamak üzere tasarlandı."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Adsız Alan"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Alan {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Proje taslağı eksik veya geometrisi yok."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Proje anahat geometrisinin koordinatları yoktur."
 
@@ -2168,8 +2212,8 @@ msgstr "Temizle"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Form Seçenekleri:"
 
@@ -2191,7 +2235,7 @@ msgstr "Özel GeoJSON Yükle"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "veya"
 
@@ -2275,7 +2319,7 @@ msgid "Project Location"
 msgstr "Proje Konumu"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Anket Formu"
 
@@ -2308,39 +2352,39 @@ msgstr ""
 "Bu projeye resim ve video gibi ek medya dosyaları yüklemeniz gerekiyorsa "
 "ODK Central'a giriş yapın ve form ayarlarından yükleyin."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Haritalama İçin Hazır"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR kodu yükleniyor..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Ortak çalışan formu yükleniyor..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Proje Kurulumu"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Proje Kurulumu"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "Proje AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Adım 3: Veri Al"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI'yi Böl"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Projeyi Sonlandır"
 
@@ -2394,7 +2438,7 @@ msgstr "çoklu çizgiler"
 msgid "points"
 msgstr "noktalar"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "özellikler"
@@ -2430,7 +2474,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "İndiriliyor..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM Verisini İndir"
@@ -2447,7 +2491,7 @@ msgstr "Karelere Böl"
 msgid "Split by buildings"
 msgstr "Binalara Göre Böl"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Tekrar Böl"
@@ -2542,6 +2586,129 @@ msgstr "%(project_type)s içinde proje oluşturuluyor... Bu biraz zaman alabilir
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Hata:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2735,7 +2902,14 @@ msgstr ""
 "Yönetici hesabı otomatik olarak oluşturulamadı. Projeyi yönetmek için "
 "QFieldCloud'a admin olarak giriş yapın."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Görev Seçimlerini Kabul Et"
 
@@ -2864,95 +3038,104 @@ msgstr ""
 "haritacıların her şeyi sıfırdan toplaması için boş bir haritayla "
 "başlayın."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Boş haritayla başla"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Özel GeoJSON Yükle"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Bu proje için önerilen varsayılanlar aktiftir."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Ne indirilecek"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM Binaları"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM Yolları"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM Sağlık"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM Tuvaletler"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM Dini Yerler"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM Arazi Kullanımı"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM Su Yolları"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM Su Noktaları"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM Atık Bertarafı"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM Eğitim"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM Mezarlıklar"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM Donatıları"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "özellikler"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligon"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Çoklu çizgi"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Nokta"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Merkez noktaları kullan (OSM Veri İndirme için)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Çokgenleri tek noktalara dönüştür."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM veri çıkarımı oluşturuluyor... Bu biraz zaman alabilir."
 
@@ -2985,11 +3168,21 @@ msgstr ""
 "görevlere bölün. Aşağıda nasıl bölüneceğini seçin, sonucu önizleyin ve "
 "kabul edin. Ya da tüm alanı tek görev olarak kullanmak için atlayın."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Bölünüyor..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2998,79 +3191,79 @@ msgstr ""
 "Bina sayısına göre bölerken, bu çizgisel ögeler doğal görev sınırları "
 "olarak kullanılır."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Yolları dahil et"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Nehirleri dahil et"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Demiryollarını dahil et"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Hava yollarını dahil et"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Nasıl bölünsün"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Bir yöntem seçin..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Bina sayısına göre (daha hızlı)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Bina sayısına göre (daha temiz şekiller)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Düzenli ızgaraya göre"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Belirli Sayıda Göreve Böl (Yakında)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Görev Başına Ortalama Bina:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Görev Sayısı:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Izgara karesi boyutu (metre)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Tekrar Böl"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI görevlere bölünüyor... Bu biraz zaman alabilir."
 

--- a/src/backend/app/locales/ur/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/ur/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ur\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s ناکام ہوگیا۔"
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API نے HTTP %(status_code)s واپس کر دیا۔"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "YAML فارم کو XLSForm میں تبدیل کرنے میں ناکام۔"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "ایک درست .xls یا .xlsx فائل فراہم کریں"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "ایک درست .xls یا .xlsx فائل فراہم کریں"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "ایک درست .xls یا .xlsx فائل فراہم کریں"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "raw-data-api میں لاگ ان نہیں ہو سکا"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "کوئی جیومیٹریز موجود نہیں ہے۔"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "آپ کی جیوسن فائل غلط ہے۔"
 
@@ -258,44 +258,44 @@ msgstr "میپنگ سرور سے جڑتے وقت توثیق ناکام ہو گئ
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "QR کوڈ بناتے وقت ایک غیر متوقع خرابی پیش آئی۔"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "منصوبہ (%(project_id)s) نہیں ملا۔"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "صرف منصوبہ منتظم ہی اس منصوبے کو حذف کر سکتا ہے۔"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "منصوبہ نہیں ملا۔"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "خرابی: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "مندرجہ ذیل صارف (صارفین) کو بطور پروجیکٹ ایڈیٹرز شامل کیا گیا: %(names)s۔"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "'%(username)s' کو شامل نہیں کیا جا سکا: %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "مزید ساتھیوں کو شامل کریں۔"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "QFieldCloud کے ساتھیوں کو مدعو کریں۔"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -303,7 +303,7 @@ msgstr ""
 "Mappers کے پاس QFieldCloud پر ایک اکاؤنٹ ہونا ضروری ہے اس سے پہلے کہ آپ "
 "انہیں اس پروجیکٹ تک رسائی دے سکیں۔"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -313,7 +313,7 @@ msgstr ""
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> پر ایک "
 "مفت اکاؤنٹ بنانے کو کہیں۔"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -323,23 +323,23 @@ msgstr ""
 "الگ) اور جمع کروائیں پر کلک کریں۔ انہیں ایڈیٹرز کے طور پر شامل کیا جائے "
 "گا اور وہ میپنگ شروع کرنے کے لیے QField میں لاگ ان کر سکتے ہیں۔"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "جیسے ایلس، باب، چارلی"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "ساتھیوں کو شامل کریں۔"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "کم از کم ایک QFieldCloud صارف نام درج کریں۔"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "اس پروجیکٹ کے لیے QFieldCloud پروجیکٹ ID نہیں ملی۔"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -347,18 +347,42 @@ msgstr ""
 "یہ پروجیکٹ اپنی مرضی کے مطابق QFieldCloud مثال پر بنایا گیا تھا۔ تعاون "
 "کنندگان کا نظم کرنے کے لیے QFieldCloud ایڈمن ٹیب کا استعمال کریں۔"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON ایکسپورٹ صرف QField پروجیکٹس کے لیے دستیاب ہے۔"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "یہ پروجیکٹ ابھی تک QFieldCloud پروجیکٹ سے منسلک نہیں ہے۔"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "GeoJSON برآمد کرنے میں ناکام: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "منصوبہ نہیں ملا یا رسائی مسترد ہے۔"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -404,11 +428,6 @@ msgid ""
 msgstr ""
 "اس تعیناتی میں QField بیس میپ منسلک کرنا ترتیب نہیں دیا گیا۔ %(config)s "
 "موجود نہیں ہے۔"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "منصوبہ نہیں ملا یا رسائی مسترد ہے۔"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -721,7 +740,7 @@ msgstr ""
 "GeoJSON فائل اپ لوڈ کریں۔"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "منصوبے کا AOI"
 
@@ -794,25 +813,25 @@ msgstr ""
 "ODK URL، صارف نام، اور پاس ورڈ (تینوں) فراہم کریں، یا سرور کی طے شدہ "
 "ترتیبات استعمال کرنے کے لیے سب خالی چھوڑ دیں۔"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "ڈیٹا ایکسٹریکٹ (%(data_feature_count)s خصوصیات)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "کام کی حدیں (%(task_count)s کام)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ٹاسک آئی ڈی"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "عمارتوں کی تعداد"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -820,7 +839,7 @@ msgstr ""
 "کوئی کامی حد نہیں ملی۔ براہ کرم پہلے اوپر موجود \"Split AOI\" بٹن سے "
 "منصوبے کو کاموں میں تقسیم کریں۔"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -829,7 +848,7 @@ msgstr ""
 "✓ AOI کامیابی سے تقسیم ہو گیا! %(algorithm)s کی مدد سے %(task_count)s "
 "کامی علاقے بنائے گئے۔"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -920,29 +939,29 @@ msgstr "کامی علاقوں کے ڈیٹا کا فارمیٹ درست نہیں�
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ تقسیم شدہ کام کامیابی سے محفوظ ہو گئے"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -951,7 +970,7 @@ msgstr ""
 "رقبہ %(area_km2)s km² ہے، جو %(area_limit)s km² کی حد سے زیادہ ہے۔ براہ "
 "کرم اپنے پروجیکٹ کا رقبہ کم کریں۔"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -960,47 +979,47 @@ msgstr ""
 "رقبہ %(area_km2)s km² ہے۔ بڑے علاقے (>%(area_warn)s km²) کو پروسیس ہونے "
 "میں زیادہ وقت لگ سکتا ہے۔"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON ضروری ہے"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "کوئی پولیگون جیومیٹری نہیں ملی۔ منصوبے کا علاقہ پولیگون ہونا چاہیے۔"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "منتخب کردہ علاقہ بہت بڑا ہے۔ براہ کرم 200 km² سے چھوٹا علاقہ منتخب کریں۔"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "خام ڈیٹا API سے ڈیٹا نکالنے میں ناکام۔"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "منصوبہ نہیں ملا۔"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "منصوبہ نہیں ملا۔"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "منصوبہ نہیں ملا۔"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "منصوبہ نہیں ملا۔"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "ٹیمپلیٹ فارم لوڈ نہیں ہو سکا۔"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1009,25 +1028,50 @@ msgstr ""
 "OpenStreetMap کو بہتر بنانے کے لیے عمارتوں کا ڈیٹا جمع کرنے کے لیے تیار "
 "کیا گیا ہے۔"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "بے نام علاقہ"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "علاقہ {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "پروجیکٹ کا خاکہ غائب ہے یا اس میں کوئی جیومیٹری نہیں ہے۔"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "پروجیکٹ آؤٹ لائن جیومیٹری میں کوئی نقاط نہیں ہیں۔"
 
@@ -2156,8 +2200,8 @@ msgstr "صاف کریں"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "فارم کے اختیارات:"
 
@@ -2179,7 +2223,7 @@ msgstr "کسٹم GeoJSON اپ لوڈ کریں"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "یا"
 
@@ -2263,7 +2307,7 @@ msgid "Project Location"
 msgstr "منصوبے کا مقام"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "سروے فارم"
 
@@ -2297,39 +2341,39 @@ msgstr ""
 "لوڈ کرنی ہیں تو ODK Central میں لاگ اِن کریں اور انہیں فارم سیٹنگز میں اپ"
 " لوڈ کریں۔"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "نقشہ سازی کے لیے تیار"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "QR کوڈ لوڈ ہو رہا ہے..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "معاون فارم لوڈ ہو رہا ہے..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "منصوبہ سیٹ اپ"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "منصوبہ سیٹ اپ"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "منصوبے کا AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "مرحلہ 3: ڈیٹا حاصل کریں"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "AOI تقسیم کریں"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "منصوبہ حتمی بنائیں"
 
@@ -2381,7 +2425,7 @@ msgstr "پولی لائنز"
 msgid "points"
 msgstr "نقاط"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "خصوصیات"
@@ -2417,7 +2461,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "ڈاؤن لوڈ ہو رہا ہے..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "OSM ڈیٹا ڈاؤن لوڈ کریں"
@@ -2434,7 +2478,7 @@ msgstr "چوکور کے مطابق تقسیم کریں"
 msgid "Split by buildings"
 msgstr "عمارتوں کے مطابق تقسیم کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "دوبارہ تقسیم کریں"
@@ -2526,6 +2570,129 @@ msgstr "%(project_type)s میں منصوبہ بنایا جا رہا ہے... اس
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "خرابی:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2719,7 +2886,14 @@ msgstr ""
 "منیجر اکاؤنٹ خودکار طور پر نہیں بنایا جا سکا۔ منصوبے کا انتظام کرنے کے "
 "لیے admin کے طور پر QFieldCloud میں لاگ اِن کریں۔"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "کام کے اختیارات قبول کریں"
 
@@ -2847,95 +3021,104 @@ msgstr ""
 "اپنے منصوبے کے علاقے کے لیے OpenStreetMap سے موجودہ فیچرز حاصل کریں، یا "
 "خالی نقشے سے شروع کریں تاکہ میپرز سب کچھ شروع سے جمع کر سکیں۔"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "خالی نقشے سے شروع کریں"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "کسٹم GeoJSON اپ لوڈ کریں"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "اس منصوبے کے لیے تجویز کردہ طے شدہ ترتیبات فعال ہیں۔"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "کیا ڈاؤن لوڈ کرنا ہے"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM عمارتیں"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM سڑکیں"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM صحت کی سہولیات"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM بیت الخلا"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM مذہبی مقامات"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM زمین کا استعمال"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM آبی راستے"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM پانی کے مقامات"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM فضلہ تلفی"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM تعلیم"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM قبرستان"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM سہولیات"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "خصوصیات"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "پولیگون"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "پولی لائن"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "نقطہ"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "سینٹروئیڈ استعمال کریں (OSM ڈیٹا ڈاؤن لوڈ کے لیے)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "پولیگونز کو واحد پوائنٹس میں تبدیل کریں۔"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "OSM ڈیٹا ایکسٹریکٹ تیار کیا جا رہا ہے... اس میں کچھ وقت لگ سکتا ہے۔"
 
@@ -2968,11 +3151,21 @@ msgstr ""
 "سکیں۔ نیچے تقسیم کا طریقہ منتخب کریں، نتیجہ دیکھیں، پھر قبول کریں۔ یا "
 "پورے علاقے کو ایک کام کے طور پر استعمال کرنے کے لیے چھوڑ دیں۔"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "تقسیم ہو رہی ہے..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2981,79 +3174,79 @@ msgstr ""
 "عمارتوں کی تعداد کے حساب سے تقسیم کرتے وقت، یہ خطی فیچرز قدرتی کام کی "
 "حدود کے طور پر استعمال ہوتے ہیں۔"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "سڑکیں شامل کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "دریا شامل کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "ریلوے شامل کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "ہوائی راستے شامل کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "کیسے تقسیم کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "طریقہ منتخب کریں..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "عمارتوں کی تعداد کے لحاظ سے (تیز)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "عمارتوں کی تعداد کے لحاظ سے (صاف شکلیں)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "باقاعدہ گرڈ کے لحاظ سے"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "مخصوص تعداد کے کاموں کے مطابق تقسیم کریں (جلد آ رہا ہے)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "فی کام اوسط عمارتیں:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "کاموں کی تعداد:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "گرڈ مربع کا سائز (میٹر)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "دوبارہ تقسیم کریں"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "AOI کو کاموں میں تقسیم کیا جا رہا ہے... اس میں کچھ وقت لگ سکتا ہے۔"
 

--- a/src/backend/app/locales/vi/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/vi/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: tech@hotosm.org\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-18 15:17+0000\n"
 "Last-Translator: Sam Woodcock sam.woodcock@hotosm.org\n"
 "Language: vi\n"
@@ -160,31 +160,31 @@ msgstr "%(action)s không thành công do lỗi kết nối ngược dòng."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "trả về HTTP %(status_code)s."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Không thể chuyển đổi biểu mẫu YAML sang XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Cung cấp tệp .xls hoặc .xlsx hợp lệ"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Cung cấp tệp .xls hoặc .xlsx hợp lệ"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Cung cấp tệp .xls hoặc .xlsx hợp lệ"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Không thể đăng nhập vào raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Không có hình học nào"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Tệp Geojson của bạn không hợp lệ."
 
@@ -259,44 +259,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Đã xảy ra lỗi không mong muốn khi tạo mã QR."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "Không tìm thấy dự án (%(project_id)s)."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Chỉ quản lý dự án mới có thể xóa dự án này."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "Không tìm thấy dự án."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Lỗi: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Đã thêm (những) người dùng sau làm người chỉnh sửa dự án: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Không thể thêm '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Thêm cộng tác viên"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Mời cộng tác viên QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -304,7 +304,7 @@ msgstr ""
 "Người lập bản đồ phải có tài khoản trên QFieldCloud trước khi bạn có thể "
 "cấp cho họ quyền truy cập vào dự án này."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -314,7 +314,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -324,23 +324,23 @@ msgstr ""
 "phẩy cho nhiều người dùng) và nhấp vào gửi. Họ sẽ được thêm làm người "
 "chỉnh sửa và có thể đăng nhập vào QField để bắt đầu lập bản đồ."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "ví dụ. Alice, Bob, Charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Thêm cộng tác viên"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Nhập ít nhất một tên người dùng QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "Không tìm thấy ID dự án QFieldCloud cho dự án này."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -348,18 +348,42 @@ msgstr ""
 "Dự án này được tạo trên phiên bản QFieldCloud tùy chỉnh. Sử dụng tab Quản"
 " trị QFieldCloud để quản lý cộng tác viên."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "Xuất GeoJSON chỉ khả dụng cho các dự án QField."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Dự án này chưa được liên kết với dự án QFieldCloud."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Không xuất được GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "Không tìm thấy dự án hoặc bị từ chối truy cập."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -405,11 +429,6 @@ msgid ""
 msgstr ""
 "Chức năng đính kèm bản đồ nền QField chưa được cấu hình trên triển khai "
 "này. Thiếu %(config)s."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "Không tìm thấy dự án hoặc bị từ chối truy cập."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -724,7 +743,7 @@ msgstr ""
 " GeoJSON trước."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI của dự án"
 
@@ -797,25 +816,25 @@ msgstr ""
 "Cung cấp URL ODK, tên người dùng và mật khẩu (cả 3), hoặc để trống tất cả"
 " để dùng mặc định của máy chủ."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Trích xuất dữ liệu (%(data_feature_count)s đối tượng)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Ranh giới nhiệm vụ (%(task_count)s nhiệm vụ)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID nhiệm vụ"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Số lượng tòa nhà"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -823,7 +842,7 @@ msgstr ""
 "Không tìm thấy ranh giới nhiệm vụ. Vui lòng chia dự án thành các nhiệm vụ"
 " trước bằng nút \"Split AOI\" ở trên."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -832,7 +851,7 @@ msgstr ""
 "✓ AOI đã được chia thành công! Đã tạo %(task_count)s khu vực nhiệm vụ "
 "bằng %(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -923,29 +942,29 @@ msgstr "Định dạng dữ liệu khu vực nhiệm vụ không hợp lệ."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ Đã lưu thành công các nhiệm vụ đã chia"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -954,7 +973,7 @@ msgstr ""
 "Diện tích là %(area_km2)s km², vượt quá giới hạn %(area_limit)s km². Vui "
 "lòng giảm diện tích dự án."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -963,47 +982,47 @@ msgstr ""
 "Diện tích là %(area_km2)s km². Các khu vực lớn (>%(area_warn)s km²) có "
 "thể mất nhiều thời gian xử lý hơn."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "Yêu cầu GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "Không tìm thấy hình học đa giác. Khu vực dự án phải là đa giác."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Vùng được chọn quá lớn. Vui lòng chọn khu vực nhỏ hơn 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Không thể tạo trích xuất dữ liệu từ API dữ liệu thô."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "Không tìm thấy dự án."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "Không tìm thấy dự án."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "Không tìm thấy dự án."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "Không tìm thấy dự án."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Không tải được biểu mẫu mẫu."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1011,25 +1030,50 @@ msgstr ""
 "Dự án này được tạo bằng quy trình đơn giản hóa trong FieldTM và nhằm thu "
 "thập dữ liệu về tòa nhà để cải thiện OpenStreetMap."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Khu vực chưa có tên"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Khu vực {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "Phác thảo dự án bị thiếu hoặc không có hình học."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "Hình học phác thảo dự án không có tọa độ."
 
@@ -2170,8 +2214,8 @@ msgstr "Xóa"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Tùy chọn biểu mẫu:"
 
@@ -2193,7 +2237,7 @@ msgstr "Tải GeoJSON tùy chỉnh"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "hoặc"
 
@@ -2275,7 +2319,7 @@ msgid "Project Location"
 msgstr "Vị trí dự án"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Biểu mẫu khảo sát"
 
@@ -2309,39 +2353,39 @@ msgstr ""
 " án này, hãy đăng nhập vào ODK Central và tải chúng lên trong phần cài "
 "đặt biểu mẫu."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Sẵn sàng lập bản đồ"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "Đang tải mã QR..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Đang tải biểu mẫu cộng tác viên..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Thiết lập dự án"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Thiết lập dự án"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI của dự án"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Bước 3: Lấy dữ liệu"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Chia AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Hoàn tất dự án"
 
@@ -2395,7 +2439,7 @@ msgstr "đường gấp khúc"
 msgid "points"
 msgstr "điểm"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "đối tượng"
@@ -2431,7 +2475,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "Đang tải xuống..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Tải dữ liệu OSM"
@@ -2448,7 +2492,7 @@ msgstr "Chia theo ô vuông"
 msgid "Split by buildings"
 msgstr "Chia theo công trình"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Chia lại"
@@ -2540,6 +2584,129 @@ msgstr "Đang tạo dự án trong %(project_type)s... Việc này có thể m�
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Lỗi:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2737,7 +2904,14 @@ msgstr ""
 "Không thể tạo tài khoản quản lý tự động. Hãy đăng nhập QFieldCloud với tư"
 " cách admin để quản lý dự án."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Chấp nhận lựa chọn nhiệm vụ"
 
@@ -2866,95 +3040,104 @@ msgstr ""
 "hoặc bắt đầu với bản đồ trống để người lập bản đồ thu thập mọi thứ từ "
 "đầu."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Bắt đầu với bản đồ trống"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Tải GeoJSON tùy chỉnh"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Các cài đặt mặc định được khuyến nghị đang áp dụng cho dự án này."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Nội dung cần tải xuống"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Công trình OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Đường OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Y tế OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Nhà vệ sinh OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Tôn giáo OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Sử dụng đất OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Đường thủy OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Điểm nước OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Xử lý chất thải OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Giáo dục OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Nghĩa trang OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Tiện ích OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "đối tượng"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Đa giác"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Đường gấp khúc"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Điểm"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Dùng trọng tâm (Để tải dữ liệu OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Chuyển đa giác thành các điểm đơn."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "Đang tạo bản trích xuất dữ liệu OSM... Việc này có thể mất một lúc."
 
@@ -2987,11 +3170,21 @@ msgstr ""
 " có thể làm song song. Chọn cách chia bên dưới, xem trước kết quả rồi "
 "chấp nhận. Hoặc bỏ qua để dùng toàn bộ khu vực làm một nhiệm vụ."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "Đang chia..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -3000,79 +3193,79 @@ msgstr ""
 "Khi chia theo số lượng tòa nhà, các đối tượng tuyến tính này được dùng "
 "làm ranh giới nhiệm vụ tự nhiên."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Bao gồm đường"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Bao gồm sông"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Bao gồm đường sắt"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Bao gồm đường hàng không"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Cách chia"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Chọn phương pháp..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Theo số lượng tòa nhà (nhanh hơn)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Theo số lượng tòa nhà (hình dạng gọn hơn)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Theo lưới đều"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Chia theo số lượng nhiệm vụ cụ thể (Sắp có)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Số công trình trung bình mỗi nhiệm vụ:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Số lượng nhiệm vụ:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Kích thước ô lưới (mét)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Chia lại"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "Đang chia AOI thành các nhiệm vụ... Việc này có thể mất một lúc."
 

--- a/src/backend/app/locales/yo/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/yo/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: yo\n"
@@ -159,31 +159,31 @@ msgstr "%(action)s kuna nitori aṣiṣe asopọ oke."
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API da HTTP %(status_code)s pada."
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "Kuna lati yi fọọmu YAML pada si XLSForm."
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "Pese fáìlì .xls tàbí .xlsx tó wulo"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "Pese fáìlì .xls tàbí .xlsx tó wulo"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "Pese fáìlì .xls tàbí .xlsx tó wulo"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "Ko le buwolu wọle si raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "Ko si awọn geoometries ti o wa"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "Faili geojson rẹ ko wulo."
 
@@ -258,44 +258,44 @@ msgstr ""
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "Aṣiṣe airotẹlẹ ṣẹlẹ nígbà tí a ń dá kóòdù QR sílẹ̀."
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "A kò rí iṣẹ́ (%(project_id)s)."
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "Alákóso iṣẹ́ nìkan ló lè pa iṣẹ́ yìí rẹ́."
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "A kò rí iṣẹ́ náà."
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "Aṣiṣe: %(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "Ṣafikun awọn olumulo wọnyi gẹgẹbi awọn olootu iṣẹ: %(names)s."
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "Ko le fikun '%(username)s': %(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "Ṣafikun awọn alabaṣiṣẹpọ diẹ sii"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "Pe awọn alabaṣiṣẹpọ QFieldCloud"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
@@ -303,7 +303,7 @@ msgstr ""
 "Awọn Mappers gbọdọ ni akọọlẹ kan lori QFieldCloud ṣaaju ki o to fun wọn "
 "ni iraye si iṣẹ akanṣe yii."
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -313,7 +313,7 @@ msgstr ""
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
 "class=\"ftm-link--brand\">app.qfield.cloud</a>."
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
@@ -323,23 +323,23 @@ msgstr ""
 "olumulo) ki o tẹ fi silẹ. Wọn yoo fi kun bi awọn olootu ati pe o le wọle "
 "si QField lati bẹrẹ ṣiṣe aworan."
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "f.eks. alice, Bob, charlie"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "Ṣafikun awọn alabaṣiṣẹpọ"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "Tẹ ni o kere kan QFieldCloud orukọ olumulo."
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "ID iṣẹ akanṣe QFieldCloud ko ri fun iṣẹ akanṣe yii."
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
@@ -347,18 +347,42 @@ msgstr ""
 "Yi ise agbese ti a da lori aṣa QFieldCloud apẹẹrẹ. Lo taabu Admin "
 "QFieldCloud lati ṣakoso awọn alabaṣiṣẹpọ."
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON okeere wa fun awọn iṣẹ akanṣe QField nikan."
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "Yi ise agbese ti wa ni ko sibẹsibẹ sopọ si a QFieldCloud ise agbese."
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "Kuna lati okeere GeoJSON: %(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "A kò rí iṣẹ́ náà tàbí a kọ ọ́ láàyè."
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -402,11 +426,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "A kò tíì túnto fifi basemap QField pọ sí ìfìdíkalẹ̀ yìí. %(config)s ò sí."
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "A kò rí iṣẹ́ náà tàbí a kọ ọ́ láàyè."
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -717,7 +736,7 @@ msgstr ""
 "GeoJSON sókè kọ́kọ́."
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "AOI iṣẹ́"
 
@@ -790,25 +809,25 @@ msgstr ""
 "Pese ODK URL, orúkọ olumulo, àti ọ̀rọ̀ aṣínà (gbogbo mẹ́ta), tàbí fi "
 "gbogbo wọn sílẹ̀ ní àfojúdi láti lò àwọn ètò àìyẹsẹ̀ olupin."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "Ìyọkúrò data (%(data_feature_count)s àwọn ẹ̀yà)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "Ààlà iṣẹ́ (%(task_count)s iṣẹ́)"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "ID Iṣẹ-ṣiṣe"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "Iye Awọn Ile"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
@@ -816,7 +835,7 @@ msgstr ""
 "A kò rí ààlà iṣẹ́ kankan. Jọwọ kọ́kọ́ pín iṣẹ́ náà sí àwọn iṣẹ́ kéékèèké "
 "pẹ̀lú bọtìnì \"Split AOI\" tó wà lókè."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
@@ -825,7 +844,7 @@ msgstr ""
 "✓ A pín AOI ní àṣeyọrí! A ṣẹ̀dá agbègbè iṣẹ́ %(task_count)s pẹ̀lú "
 "%(algorithm)s."
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -916,29 +935,29 @@ msgstr "Ọ̀nà ìṣètò data agbègbè iṣẹ́ kò tọ́."
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ A ti fipamọ́ àwọn iṣẹ́ tí a pín ní àṣeyọrí"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
@@ -947,7 +966,7 @@ msgstr ""
 "Agbegbe naa jẹ %(area_km2)s km², eyi ti o kọja opin %(area_limit)s km². "
 "Jọwọ dinku agbegbe iṣẹ́ akanṣe rẹ."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
@@ -956,47 +975,47 @@ msgstr ""
 "Agbegbe naa jẹ %(area_km2)s km². Awọn agbegbe nla (>%(area_warn)s km²) le"
 " gba akoko diẹ sii lati ṣiṣẹ."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "GeoJSON jẹ́ dandan"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "A kò rí polygon geometries kankan. Agbègbè iṣẹ́ gbọ́dọ̀ jẹ́ polygon."
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "Agbegbe ti a yan ti tobi ju. Jọwọ yan agbegbe ti o kere ju 200 km²."
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "Kuna lati ṣe ipilẹṣẹ data jade lati API data aise."
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "A kò rí iṣẹ́ náà."
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "A kò rí iṣẹ́ náà."
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "A kò rí iṣẹ́ náà."
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "A kò rí iṣẹ́ náà."
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "Kò ṣee ṣe láti kó fọ́ọ̀mù àpẹrẹ wọlé."
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
@@ -1004,25 +1023,50 @@ msgstr ""
 "A ṣẹda iṣẹ akanṣe yii pẹlu ilana iṣẹ ti a rọọrun ni FieldTM, a sì ṣe e "
 "lati ko data awọn ile jọ lati mu OpenStreetMap dara si."
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "Agbegbe Ailórúkọ"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "Agbegbe {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "sonu tabi ko ni geometry."
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "ko ni awọn ipoidojuko."
 
@@ -2148,8 +2192,8 @@ msgstr "Nu"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "Àwọn aṣayan fọ́ọ̀mù:"
 
@@ -2171,7 +2215,7 @@ msgstr "Gbe GeoJSON àdáni sókè"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "tabi"
 
@@ -2254,7 +2298,7 @@ msgid "Project Location"
 msgstr "Ibi iṣẹ́"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "Fọọmu Ìwádìí"
 
@@ -2287,39 +2331,39 @@ msgstr ""
 "Tí o bá nílò láti gbe àwọn fáìlì media míì sókè sí iṣẹ́ yìí, bíi àwòrán "
 "àti fídíò, wọlé sí ODK Central kí o sì gbe wọn sókè nínú ètò fọ́ọ̀mù."
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "Ti ṣetan fún ṣíṣe maapu"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "A ń gbé kóòdù QR wọlé..."
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "Nkojọpọ fọọmu alabaṣiṣẹpọ..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "Ìṣètò iṣẹ́"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "Ìṣètò iṣẹ́"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "AOI iṣẹ́"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "Ìgbésẹ̀ 3: Gba data"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "Pín AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "Parí iṣẹ́"
 
@@ -2371,7 +2415,7 @@ msgstr "polyline"
 msgid "points"
 msgstr "àwọn àmì"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "àwọn ẹ̀yà"
@@ -2406,7 +2450,7 @@ msgstr ""
 msgid "Downloading..."
 msgstr "A ń gba a wọlé..."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "Gba data OSM wọlé"
@@ -2423,7 +2467,7 @@ msgstr "Pín nípasẹ̀ onígun mẹ́rin"
 msgid "Split by buildings"
 msgstr "Pín nípasẹ̀ ilé"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "Tun pín"
@@ -2516,6 +2560,129 @@ msgstr "A ń dá iṣẹ́ sílẹ̀ nínú %(project_type)s... Èyí lè gba à
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "Aṣiṣe:"
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2709,7 +2876,14 @@ msgstr ""
 "A kò lè dá àkọọlẹ alákóso sílẹ̀ laifọwọyi. Wọlé sí QFieldCloud gẹ́gẹ́ bí "
 "admin láti ṣakoso iṣẹ́ náà."
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "Gba àwọn yíyàn iṣẹ́"
 
@@ -2837,95 +3011,104 @@ msgstr ""
 "Fa awọn ẹya to wa tẹlẹ lati OpenStreetMap fun agbegbe iṣẹ́ akanṣe rẹ, "
 "tabi bẹrẹ pẹlu maapu ofo ki awọn alamaapu le kojọ ohun gbogbo lati ibẹrẹ."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "Bẹrẹ pẹlu maapu ofo"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "Gbe GeoJSON àdáni sókè"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "Àwọn àìyẹsẹ̀ tí a ṣeduro ti ṣiṣẹ́ fún iṣẹ́ yìí."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "Ohun lati gba lati ayelujara"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "Ilé OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "Ọ̀nà OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "Ìtọju ìlera OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "Ilé ìgbónsẹ̀ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "Ibùdó ẹ̀sìn OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "Lílò ilẹ̀ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "Ọ̀nà omi OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "Ibùdó omi OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "Ìtójú ìdọ̀tí OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "Ẹ̀kọ́ OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "Sàré OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "Àwọn ohun ìní OSM"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "àwọn ẹ̀yà"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "Poligoni"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "Polilaini"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "Àmì"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "Lo centroid (Fún ìgbàfáwèé dátà OSM)"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "Yi polygons pada si awọn aaye kọọkan."
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "A ń ṣe ìyọkúrò data OSM... Èyí lè gba àkókò díẹ̀."
 
@@ -2958,11 +3141,21 @@ msgstr ""
 "Yan bi o ṣe fẹ pin ni isalẹ, wo abajade ṣaaju, lẹhinna gba a. Tabi foju "
 "lati lo gbogbo agbegbe gẹgẹ bi iṣẹ kan."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "A ń pín..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
@@ -2971,79 +3164,79 @@ msgstr ""
 "Nigbati a ba pin nipa iye awọn ilé, awọn ẹya ila wọnyi ni a lo gẹgẹ bi "
 "ààlà iṣẹ adayeba."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "Fi ọ̀nà kún un"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "Fi odò kún un"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "Fi ojú irin kún un"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "Fi ọ̀nà ojú òfurufú kún un"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "Bawo ni a ṣe pin"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "Yan ọna kan..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "Nipa iye awọn ilé (yara ju)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "Nipa iye awọn ilé (awọn apẹrẹ mimọ diẹ sii)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "Nipa grid deede"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "Pín gẹ́gẹ́ bí iye iṣẹ́ kan pàtó (yóò dé láìpẹ́)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "Apapọ ilé fún iṣẹ́ kọọkan:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "Nọ́mbà iṣẹ́:"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "Iwọn onigun grid (mita)"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "Tun pín"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "A ń pín AOI sí iṣẹ́... Èyí lè gba àkókò díẹ̀."
 

--- a/src/backend/app/locales/zh/LC_MESSAGES/field_tm.po
+++ b/src/backend/app/locales/zh/LC_MESSAGES/field_tm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Field-TM VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-06 03:42+0100\n"
+"POT-Creation-Date: 2026-06-12 21:52-0400\n"
 "PO-Revision-Date: 2026-03-19 22:03+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh\n"
@@ -157,31 +157,31 @@ msgstr "%(action)s 失败。"
 msgid "Tilepack API returned HTTP %(status_code)s."
 msgstr "Tilepack API 返回 HTTP %(status_code)s。"
 
-#: app/helpers/helper_routes.py:78
+#: app/helpers/helper_routes.py:81
 msgid "Failed to convert YAML form to XLSForm."
 msgstr "无法将 YAML 表单转换为 XLSForm。"
 
-#: app/helpers/helper_routes.py:101
+#: app/helpers/helper_routes.py:104
 msgid "Provide a valid .json or .geojson file"
 msgstr "请提供有效的 .xls 或 .xlsx 文件"
 
-#: app/helpers/helper_routes.py:139
+#: app/helpers/helper_routes.py:149
 msgid "Provide a valid .csv"
 msgstr "请提供有效的 .xls 或 .xlsx 文件"
 
-#: app/helpers/helper_routes.py:193
+#: app/helpers/helper_routes.py:203
 msgid "Provide a valid .json file"
 msgstr "请提供有效的 .xls 或 .xlsx 文件"
 
-#: app/helpers/helper_routes.py:228
+#: app/helpers/helper_routes.py:238
 msgid "Could not login to raw-data-api"
 msgstr "无法登录 raw-data-api"
 
-#: app/helpers/helper_routes.py:252
+#: app/helpers/helper_routes.py:262
 msgid "No geometries present"
 msgstr "不存在几何形状"
 
-#: app/helpers/helper_routes.py:269
+#: app/helpers/helper_routes.py:279
 msgid "Your geojson file is invalid."
 msgstr "您的 geojson 文件无效。"
 
@@ -252,50 +252,50 @@ msgstr "连接制图服务器时身份验证失败。请检查已配置的凭据
 msgid "An unexpected error occurred while generating the QR code."
 msgstr "生成二维码时发生意外错误。"
 
-#: app/htmx/project_detail_routes.py:298
+#: app/htmx/project_detail_routes.py:325
 #, python-format
 msgid "Project (%(project_id)s) not found."
 msgstr "未找到项目（%(project_id)s）。"
 
-#: app/htmx/project_detail_routes.py:305
+#: app/htmx/project_detail_routes.py:332
 msgid "Only the project manager can delete this project."
 msgstr "只有项目经理可以删除此项目。"
 
-#: app/htmx/project_detail_routes.py:343 app/templates/project_details.html:299
+#: app/htmx/project_detail_routes.py:370 app/templates/project_details.html:299
 msgid "Project not found."
 msgstr "未找到项目。"
 
-#: app/htmx/project_detail_routes.py:379
+#: app/htmx/project_detail_routes.py:406
 #: app/htmx/setup_steps/setup_step_responses.py:70
 #, python-format
 msgid "Error: %(error_msg)s"
 msgstr "错误：%(error_msg)s"
 
-#: app/htmx/project_detail_routes.py:413
+#: app/htmx/project_detail_routes.py:440
 #, python-format
 msgid "Added the following user(s) as project editors: %(names)s."
 msgstr "添加了以下用户作为项目编辑者：%(names)s。"
 
-#: app/htmx/project_detail_routes.py:417
+#: app/htmx/project_detail_routes.py:444
 #, python-format
 msgid "Could not add '%(username)s': %(reason)s"
 msgstr "无法添加“%(username)s”：%(reason)s"
 
-#: app/htmx/project_detail_routes.py:423
+#: app/htmx/project_detail_routes.py:450
 msgid "Add more collaborators"
 msgstr "添加更多协作者"
 
-#: app/htmx/project_detail_routes.py:436
+#: app/htmx/project_detail_routes.py:463
 msgid "Invite QFieldCloud collaborators"
 msgstr "邀请QFieldCloud合作者"
 
-#: app/htmx/project_detail_routes.py:439
+#: app/htmx/project_detail_routes.py:466
 msgid ""
 "Mappers must have an account on QFieldCloud before you can give them "
 "access to this project."
 msgstr "制图人员必须在 QFieldCloud 上拥有帐户，然后才能授予他们访问此项目的权限。"
 
-#: app/htmx/project_detail_routes.py:445
+#: app/htmx/project_detail_routes.py:472
 msgid ""
 "Have each mapper create a free account at <a "
 "href=\"https://app.qfield.cloud\" target=\"_blank\" rel=\"noopener\" "
@@ -304,47 +304,71 @@ msgstr ""
 "让每个映射器在 <a href=\"https://app.qfield.cloud\" target=\"_blank\" "
 "rel=\"noopener\" class=\"ftm-link--brand\">app.qfield.cloud</a> 创建一个免费帐户。"
 
-#: app/htmx/project_detail_routes.py:451
+#: app/htmx/project_detail_routes.py:478
 msgid ""
 "Enter their QFieldCloud usernames below (comma-separated for multiple "
 "users) and click submit. They will be added as editors and can log in to "
 "QField to start mapping."
 msgstr "在下面输入他们的 QFieldCloud 用户名（多个用户用逗号分隔），然后单击“提交”。他们将被添加为编辑者，并可以登录 QField 开始映射。"
 
-#: app/htmx/project_detail_routes.py:457
+#: app/htmx/project_detail_routes.py:484
 msgid "e.g. alice, bob, charlie"
 msgstr "例如爱丽丝、鲍勃、查理"
 
-#: app/htmx/project_detail_routes.py:458
+#: app/htmx/project_detail_routes.py:485
 msgid "Add collaborators"
 msgstr "添加协作者"
 
-#: app/htmx/project_detail_routes.py:550
+#: app/htmx/project_detail_routes.py:577
 msgid "Enter at least one QFieldCloud username."
 msgstr "输入至少一个 QFieldCloud 用户名。"
 
-#: app/htmx/project_detail_routes.py:560
+#: app/htmx/project_detail_routes.py:587
 msgid "QFieldCloud project ID not found for this project."
 msgstr "未找到该项目的 QFieldCloud 项目 ID。"
 
-#: app/htmx/project_detail_routes.py:566
+#: app/htmx/project_detail_routes.py:593
 msgid ""
 "This project was created on a custom QFieldCloud instance. Use the "
 "QFieldCloud Admin tab to manage collaborators."
 msgstr "该项目是在自定义 QFieldCloud 实例上创建的。使用 QFieldCloud 管理选项卡来管理协作者。"
 
-#: app/htmx/project_detail_routes.py:632
+#: app/htmx/project_detail_routes.py:659
 msgid "GeoJSON export is only available for QField projects."
 msgstr "GeoJSON 导出仅适用于 QField 项目。"
 
-#: app/htmx/project_detail_routes.py:637
+#: app/htmx/project_detail_routes.py:664
 msgid "This project is not yet linked to a QFieldCloud project."
 msgstr "该项目尚未链接到 QFieldCloud 项目。"
 
-#: app/htmx/project_detail_routes.py:648
+#: app/htmx/project_detail_routes.py:675
 #, python-format
 msgid "Failed to export GeoJSON: %(error)s"
 msgstr "无法导出 GeoJSON：%(error)s"
+
+#: app/htmx/assignment/assignment_routes.py:223
+#: app/htmx/basemap/basemap_fragments.py:17
+#: app/htmx/setup_steps/setup_step_responses.py:90
+msgid "Project not found or access denied."
+msgstr "未找到项目或访问被拒绝。"
+
+#: app/htmx/assignment/assignment_routes.py:230
+#: app/projects/project_services.py:1285
+msgid "No task areas to assign. Split the project area into tasks first."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:275
+msgid "No assignments data provided."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:282
+#: app/projects/project_services.py:1193 app/projects/project_services.py:1264
+msgid "Invalid assignments data format."
+msgstr ""
+
+#: app/htmx/assignment/assignment_routes.py:302
+msgid "✓ Assignments saved"
+msgstr ""
 
 #: app/htmx/basemap/basemap_attach_flow.py:69
 msgid ""
@@ -382,11 +406,6 @@ msgid ""
 "QField basemap attach is not configured on this deployment. Missing "
 "%(config)s."
 msgstr "此部署尚未配置 QField 底图附加功能。缺少 %(config)s。"
-
-#: app/htmx/basemap/basemap_fragments.py:17
-#: app/htmx/setup_steps/setup_step_responses.py:90
-msgid "Project not found or access denied."
-msgstr "未找到项目或访问被拒绝。"
 
 #: app/htmx/basemap/basemap_fragments.py:105
 msgid "Basemap attached to QField project successfully."
@@ -687,7 +706,7 @@ msgid ""
 msgstr "未找到 GeoJSON 数据。请先下载 OSM 数据或上传 GeoJSON 文件。"
 
 #: app/htmx/setup_steps/setup_step_extract_handlers.py:229
-#: app/htmx/setup_steps/setup_step_map_layers.py:27
+#: app/htmx/setup_steps/setup_step_map_layers.py:28
 msgid "Project AOI"
 msgstr "项目 AOI"
 
@@ -750,38 +769,38 @@ msgid ""
 "to use server defaults."
 msgstr "请提供 ODK URL、用户名和密码（共 3 项），或将其全部留空以使用服务器默认值。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:39
+#: app/htmx/setup_steps/setup_step_map_layers.py:40
 #, python-format
 msgid "Data Extract (%(data_feature_count)s features)"
 msgstr "数据提取（%(data_feature_count)s 个要素）"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:52
+#: app/htmx/setup_steps/setup_step_map_layers.py:53
 #, python-format
 msgid "Task Boundaries (%(task_count)s tasks)"
 msgstr "任务边界（%(task_count)s 个任务）"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:61
+#: app/htmx/setup_steps/setup_step_map_layers.py:62
 msgid "Task ID"
 msgstr "任务编号"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:62
+#: app/htmx/setup_steps/setup_step_map_layers.py:63
 msgid "Building Count"
 msgstr "建筑物数量"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:81
+#: app/htmx/setup_steps/setup_step_map_layers.py:82
 msgid ""
 "No task boundaries found. Please split the project into tasks first using"
 " the \"Split AOI\" button above."
 msgstr "未找到任务边界。请先使用上方的“Split AOI”按钮将项目拆分为任务。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:132
+#: app/htmx/setup_steps/setup_step_map_layers.py:133
 #, python-format
 msgid ""
 "✓ AOI split successfully! Generated %(task_count)s task areas using "
 "%(algorithm)s."
 msgstr "✓ AOI 拆分成功！已使用 %(algorithm)s 生成 %(task_count)s 个任务区域。"
 
-#: app/htmx/setup_steps/setup_step_map_layers.py:139
+#: app/htmx/setup_steps/setup_step_map_layers.py:140
 #, python-format
 msgid ""
 "Previewing %(task_count)s task boundaries%(data_extract_info)s. Review "
@@ -859,107 +878,132 @@ msgstr "任务区域数据格式无效。"
 msgid "✓ Split tasks saved successfully"
 msgstr "✓ 拆分任务保存成功"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:56
-msgid "Could not reach Tasking Manager. Please try again later."
-msgstr ""
-
 #: app/htmx/setup_steps/setup_step_validate_routes.py:61
-#, python-format
-msgid "Tasking Manager project %(id)s was not found."
+msgid "Could not reach Tasking Manager. Please try again later."
 msgstr ""
 
 #: app/htmx/setup_steps/setup_step_validate_routes.py:66
 #, python-format
+msgid "Tasking Manager project %(id)s was not found."
+msgstr ""
+
+#: app/htmx/setup_steps/setup_step_validate_routes.py:71
+#, python-format
 msgid "Tasking Manager returned an error (HTTP %(status)s)."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:79
+#: app/htmx/setup_steps/setup_step_validate_routes.py:84
 msgid "Tasking Manager returned an invalid response."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:89
+#: app/htmx/setup_steps/setup_step_validate_routes.py:94
 msgid "Tasking Manager project AOI did not contain any polygon geometries."
 msgstr ""
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:113
+#: app/htmx/setup_steps/setup_step_validate_routes.py:118
 #, python-format
 msgid ""
 "Area is %(area_km2)s km², which exceeds the %(area_limit)s km² limit. "
 "Please reduce your project area."
 msgstr "面积为 %(area_km2)s km²，超过 %(area_limit)s km² 的限制。请缩小项目区域。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:118
+#: app/htmx/setup_steps/setup_step_validate_routes.py:123
 #, python-format
 msgid ""
 "Area is %(area_km2)s km². Large areas (>%(area_warn)s km²) may take "
 "longer to process."
 msgstr "面积为 %(area_km2)s km²。较大区域 (>%(area_warn)s km²) 可能需要更长处理时间。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:143
+#: app/htmx/setup_steps/setup_step_validate_routes.py:148
 msgid "GeoJSON is required"
 msgstr "必须提供 GeoJSON"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:153
+#: app/htmx/setup_steps/setup_step_validate_routes.py:158
 msgid "No polygon geometries found. Project area must be a polygon."
 msgstr "未找到多边形几何。项目区域必须是多边形。"
 
-#: app/htmx/setup_steps/setup_step_validate_routes.py:196
+#: app/htmx/setup_steps/setup_step_validate_routes.py:206
 msgid "Tasking Manager project ID must be a positive integer."
 msgstr ""
 
-#: app/projects/project_crud.py:136
+#: app/projects/project_crud.py:138
 msgid "Selected area is too large. Please select an area smaller than 200 km²."
 msgstr "选择的区域太大。请选择小于200 km²的区域。"
 
-#: app/projects/project_crud.py:147
+#: app/projects/project_crud.py:149
 msgid "Failed to generate data extract from the raw data API."
 msgstr "无法从原始数据 API 生成数据提取。"
 
-#: app/projects/project_crud.py:901
+#: app/projects/project_crud.py:903
 msgid "QField project ID not found."
 msgstr "未找到项目。"
 
-#: app/projects/project_crud.py:934
+#: app/projects/project_crud.py:936
 msgid "Project name not found."
 msgstr "未找到项目。"
 
-#: app/projects/project_crud.py:941
+#: app/projects/project_crud.py:943
 msgid "ODK project ID not found."
 msgstr "未找到项目。"
 
-#: app/projects/project_crud.py:950
+#: app/projects/project_crud.py:952
 msgid "Appuser token not found."
 msgstr "未找到项目。"
 
-#: app/projects/project_crud.py:967
+#: app/projects/project_crud.py:969
 msgid "Failed to generate QR code."
 msgstr "加载模板表单失败。"
 
-#: app/projects/project_services.py:75
+#: app/projects/project_services.py:79
 msgid ""
 "This project was created with a simplified workflow in FieldTM and is "
 "made to collect building data to enhance OpenStreetMap."
 msgstr "该项目通过 FieldTM 中的简化工作流程创建，用于收集建筑数据以改进 OpenStreetMap。"
 
-#: app/projects/project_services.py:82
+#: app/projects/project_services.py:86
 msgid "Unnamed Area"
 msgstr "未命名区域"
 
-#: app/projects/project_services.py:95
+#: app/projects/project_services.py:99
 #, python-brace-format
 msgid "Area {latitude:.4f}_{longitude:.4f}"
 msgstr "区域 {latitude:.4f}_{longitude:.4f}"
 
-#: app/projects/project_services.py:412
+#: app/projects/project_services.py:416
 #, python-brace-format
 msgid "{location} OSM Buildings"
 msgstr "{location} OSM Buildings"
 
-#: app/qfield/qfield_crud.py:167
+#: app/projects/project_services.py:1200
+#, python-format
+msgid "Assignee must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1211
+#: app/templates/partials/project_details/fragments/assignment_panel.html:127
+msgid "Group labels may only contain letters, numbers, hyphens and underscores."
+msgstr ""
+
+#: app/projects/project_services.py:1217
+#, python-format
+msgid "Group labels must be %(max_length)s characters or fewer."
+msgstr ""
+
+#: app/projects/project_services.py:1302
+#, python-format
+msgid "Invalid task id: %(task_id)s"
+msgstr ""
+
+#: app/projects/project_services.py:1307
+#, python-format
+msgid "Unknown task id: %(task_id)s"
+msgstr ""
+
+#: app/qfield/qfield_crud.py:168
 msgid "Project outline is missing or has no geometry."
 msgstr "项目轮廓丢失或没有几何图形。"
 
-#: app/qfield/qfield_crud.py:173
+#: app/qfield/qfield_crud.py:174
 msgid "Project outline geometry has no coordinates."
 msgstr "项目轮廓几何没有坐标。"
 
@@ -2011,8 +2055,8 @@ msgstr "清除"
 
 #: app/templates/partials/new_project/map_section.html:32
 #: app/templates/partials/project_details/setup_steps/step2_form.html:89
-#: app/templates/partials/project_details/setup_steps/step3_data.html:72
-#: app/templates/partials/project_details/setup_steps/step4_split.html:36
+#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step4_split.html:39
 msgid "More options"
 msgstr "表单选项："
 
@@ -2034,7 +2078,7 @@ msgstr "上传自定义 GeoJSON"
 #: app/templates/partials/new_project/map_section.html:55
 #: app/templates/partials/new_project/map_section.html:56
 #: app/templates/partials/project_details/setup_steps/step2_form.html:34
-#: app/templates/partials/project_details/setup_steps/step3_data.html:59
+#: app/templates/partials/project_details/setup_steps/step3_data.html:66
 msgid "or"
 msgstr "或"
 
@@ -2110,7 +2154,7 @@ msgid "Project Location"
 msgstr "项目位置"
 
 #: app/templates/partials/project_details/manager_setup_summary.html:25
-#: app/templates/partials/project_details/setup_steps.html:65
+#: app/templates/partials/project_details/setup_steps.html:83
 msgid "Survey Form"
 msgstr "调查表"
 
@@ -2141,39 +2185,39 @@ msgid ""
 "settings."
 msgstr "如果您需要向此项目上传额外的媒体文件，例如图片和视频，请登录 ODK Central 并在表单设置中上传。"
 
-#: app/templates/partials/project_details/setup_steps.html:14
+#: app/templates/partials/project_details/setup_steps.html:21
 msgid "Ready for Mapping"
 msgstr "已准备好开始制图"
 
-#: app/templates/partials/project_details/setup_steps.html:25
+#: app/templates/partials/project_details/setup_steps.html:32
 msgid "Loading QR code..."
 msgstr "正在加载二维码……"
 
-#: app/templates/partials/project_details/setup_steps.html:37
+#: app/templates/partials/project_details/setup_steps.html:44
 msgid "Loading collaborator form..."
 msgstr "正在加载协作者表单..."
 
-#: app/templates/partials/project_details/setup_steps.html:44
+#: app/templates/partials/project_details/setup_steps.html:62
 msgid "Project Setup"
 msgstr "项目设置"
 
-#: app/templates/partials/project_details/setup_steps.html:56
+#: app/templates/partials/project_details/setup_steps.html:74
 msgid "Project setup progress"
 msgstr "项目设置"
 
-#: app/templates/partials/project_details/setup_steps.html:59
+#: app/templates/partials/project_details/setup_steps.html:77
 msgid "Project Details"
 msgstr "项目 AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:71
+#: app/templates/partials/project_details/setup_steps.html:89
 msgid "Get Data"
 msgstr "步骤 3：获取数据"
 
-#: app/templates/partials/project_details/setup_steps.html:77
+#: app/templates/partials/project_details/setup_steps.html:95
 msgid "Split Tasks"
 msgstr "拆分 AOI"
 
-#: app/templates/partials/project_details/setup_steps.html:81
+#: app/templates/partials/project_details/setup_steps.html:99
 msgid "Finalise"
 msgstr "完成项目"
 
@@ -2225,7 +2269,7 @@ msgstr "折线"
 msgid "points"
 msgstr "点"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 #: app/templates/partials/project_details/style_and_scripts.html:20
 msgid "features"
 msgstr "要素"
@@ -2254,7 +2298,7 @@ msgstr "推荐数据源已更新（%(geom_label)s）。请在地图上查看数�
 msgid "Downloading..."
 msgstr "正在下载……"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:27
+#: app/templates/partials/project_details/setup_steps/step3_data.html:31
 #: app/templates/partials/project_details/style_and_scripts.html:25
 msgid "Use OSM data"
 msgstr "下载 OSM 数据"
@@ -2271,7 +2315,7 @@ msgstr "按方格拆分"
 msgid "Split by buildings"
 msgstr "按建筑物拆分"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 #: app/templates/partials/project_details/style_and_scripts.html:30
 msgid "Split area"
 msgstr "重新拆分"
@@ -2361,6 +2405,129 @@ msgstr "正在 %(project_type)s 中创建项目……这可能需要一点时间
 #: app/templates/partials/project_details/style_and_scripts.html:50
 msgid "Error:"
 msgstr "错误："
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:8
+msgid ""
+"This project has a single task covering the whole area. Split the area "
+"into tasks to\n"
+"    assign mappers to specific task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:14
+msgid "Task Assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:16
+msgid ""
+"Select tasks on the map, then apply an assignee and group label. Changes "
+"are saved when\n"
+"    you press Save assignments."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:24
+#: app/templates/partials/project_details/fragments/assignment_summary.html:13
+msgid "Assignee"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:31
+msgid "Mapper name (free text)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:42
+msgid "Group label"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:49
+msgid "e.g. NE"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:55
+#: app/templates/partials/project_details/fragments/assignment_panel.html:122
+msgid "Apply to selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:58
+msgid "Auto-group by quadrant"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:61
+msgid "Unassign selected"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:64
+msgid "Clear selection"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:90
+msgid "Save assignments"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:117
+#: app/templates/partials/project_details/fragments/assignment_summary.html:26
+msgid "Unassigned"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:118
+#, python-format
+msgid "Task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:119
+#, python-format
+msgid "Group: %(group)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:120
+#, python-format
+msgid "Assigned to: %(name)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:121
+#, python-format
+msgid "Apply to selected (%(count)s)"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:123
+msgid "Select one or more tasks on the map first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:124
+msgid "Enter an assignee or group label to apply first."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:125
+#, python-format
+msgid "%(count)s unsaved changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:126
+msgid "Discard changes"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:128
+msgid "Could not load task areas."
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:129
+msgid "Select all tasks"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_panel.html:130
+#, python-format
+msgid "Select task %(task_id)s"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:11
+msgid "Task"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:12
+msgid "Group"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/assignment_summary.html:15
+msgid "Buildings"
+msgstr ""
 
 #: app/templates/partials/project_details/fragments/basemap_progress.html:5
 msgid ""
@@ -2548,7 +2715,14 @@ msgid ""
 "      manage the project."
 msgstr "无法自动创建管理账户。请以管理员身份登录 QFieldCloud 来管理该项目。"
 
-#: app/templates/partials/project_details/fragments/split_preview.html:27
+#: app/templates/partials/project_details/fragments/split_preview.html:25
+#, python-format
+msgid ""
+"Accepting this split discards %(count)s existing task assignment(s). "
+"Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/fragments/split_preview.html:30
 msgid "Accept Task Choices"
 msgstr "接受任务选择"
 
@@ -2666,95 +2840,104 @@ msgid ""
 "    map so mappers can collect everything from scratch."
 msgstr "从 OpenStreetMap 为你的项目区域提取现有要素，或从空地图开始，让制图员从零收集所有内容。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:53
+#: app/templates/partials/project_details/setup_steps/step3_data.html:26
+#: app/templates/partials/project_details/setup_steps/step3_data.html:55
+#: app/templates/partials/project_details/setup_steps/step3_data.html:163
+#, python-format
+msgid ""
+"Replacing the data extract discards %(count)s existing task "
+"assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step3_data.html:60
 msgid "Start with empty map"
 msgstr "从空地图开始"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:61
+#: app/templates/partials/project_details/setup_steps/step3_data.html:68
 msgid "upload your own map file (GeoJSON)"
 msgstr "上传自定义 GeoJSON"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:79
+#: app/templates/partials/project_details/setup_steps/step3_data.html:86
 msgid "Override the default OSM source for this project."
 msgstr "此项目已启用推荐默认设置。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:85
+#: app/templates/partials/project_details/setup_steps/step3_data.html:92
 msgid "What to download"
 msgstr "要下载什么"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:88
+#: app/templates/partials/project_details/setup_steps/step3_data.html:95
 msgid "OSM Buildings"
 msgstr "OSM 建筑物"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:89
+#: app/templates/partials/project_details/setup_steps/step3_data.html:96
 msgid "OSM Highways"
 msgstr "OSM 道路"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:90
+#: app/templates/partials/project_details/setup_steps/step3_data.html:97
 msgid "OSM Healthcare"
 msgstr "OSM 医疗设施"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:91
+#: app/templates/partials/project_details/setup_steps/step3_data.html:98
 msgid "OSM Toilets"
 msgstr "OSM 厕所"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:92
+#: app/templates/partials/project_details/setup_steps/step3_data.html:99
 msgid "OSM Religious"
 msgstr "OSM 宗教场所"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:93
+#: app/templates/partials/project_details/setup_steps/step3_data.html:100
 msgid "OSM Landuse"
 msgstr "OSM 土地利用"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:94
+#: app/templates/partials/project_details/setup_steps/step3_data.html:101
 msgid "OSM Waterways"
 msgstr "OSM 水道"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:95
+#: app/templates/partials/project_details/setup_steps/step3_data.html:102
 msgid "OSM Water Points"
 msgstr "OSM 取水点"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:96
+#: app/templates/partials/project_details/setup_steps/step3_data.html:103
 msgid "OSM Waste Disposal"
 msgstr "OSM 废弃物处理"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:97
+#: app/templates/partials/project_details/setup_steps/step3_data.html:104
 msgid "OSM Education"
 msgstr "OSM 教育设施"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:98
+#: app/templates/partials/project_details/setup_steps/step3_data.html:105
 msgid "OSM Cemeteries"
 msgstr "OSM 墓地"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:99
+#: app/templates/partials/project_details/setup_steps/step3_data.html:106
 msgid "OSM Amenities"
 msgstr "OSM 生活设施"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:104
+#: app/templates/partials/project_details/setup_steps/step3_data.html:111
 msgid "Feature shape"
 msgstr "要素"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:107
+#: app/templates/partials/project_details/setup_steps/step3_data.html:114
 msgid "Polygon (area)"
 msgstr "多边形"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:108
+#: app/templates/partials/project_details/setup_steps/step3_data.html:115
 msgid "Line"
 msgstr "折线"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:109
+#: app/templates/partials/project_details/setup_steps/step3_data.html:116
 msgid "Point"
 msgstr "点"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:117
+#: app/templates/partials/project_details/setup_steps/step3_data.html:124
 msgid "Use Centroids (For OSM Data Download)"
 msgstr "使用质心（用于下载 OSM 数据）"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:120
+#: app/templates/partials/project_details/setup_steps/step3_data.html:127
 msgid "Convert polygons to single points."
 msgstr "将多边形转换为单个点。"
 
-#: app/templates/partials/project_details/setup_steps/step3_data.html:142
+#: app/templates/partials/project_details/setup_steps/step3_data.html:149
 msgid "Generating OSM data extract... This may take a moment."
 msgstr "正在生成 OSM 数据提取……这可能需要一点时间。"
 
@@ -2784,90 +2967,100 @@ msgid ""
 "whole area as one task."
 msgstr "将你的区域划分为较小任务，以便多名制图员并行工作。选择下面的划分方式，预览结果，然后接受。也可以跳过，将整个区域作为一个任务。"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:29
+#: app/templates/partials/project_details/setup_steps/step4_split.html:27
+#, python-format
+msgid "This will discard %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:32
 msgid "Skip splitting"
 msgstr "正在拆分……"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:50
+#: app/templates/partials/project_details/setup_steps/step4_split.html:49
+#, python-format
+msgid "Re-splitting discards %(count)s existing task assignment(s). Continue?"
+msgstr ""
+
+#: app/templates/partials/project_details/setup_steps/step4_split.html:56
 msgid ""
 "When splitting by building count, these linear features are used as "
 "natural task\n"
 "          boundaries."
 msgstr "按建筑数量划分时，这些线状要素会用作任务的自然边界。"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:75
+#: app/templates/partials/project_details/setup_steps/step4_split.html:81
 msgid "Include roads"
 msgstr "包含道路"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:84
+#: app/templates/partials/project_details/setup_steps/step4_split.html:90
 msgid "Include rivers"
 msgstr "包含河流"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:93
+#: app/templates/partials/project_details/setup_steps/step4_split.html:99
 msgid "Include railways"
 msgstr "包含铁路"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:102
+#: app/templates/partials/project_details/setup_steps/step4_split.html:108
 msgid "Include aeroways"
 msgstr "包含航空线路"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:115
+#: app/templates/partials/project_details/setup_steps/step4_split.html:121
 msgid "How to split"
 msgstr "如何划分"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:117
+#: app/templates/partials/project_details/setup_steps/step4_split.html:123
 msgid "Choose a method..."
 msgstr "选择方法..."
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:118
+#: app/templates/partials/project_details/setup_steps/step4_split.html:124
 msgid "By number of buildings (faster)"
 msgstr "按建筑数量（更快）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:120
+#: app/templates/partials/project_details/setup_steps/step4_split.html:126
 msgid ""
 "By number of buildings (cleaner shapes) - unavailable\n"
 "            for large areas"
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:121
+#: app/templates/partials/project_details/setup_steps/step4_split.html:127
 msgid "By number of buildings (cleaner shapes)"
 msgstr "按建筑数量（形状更整洁）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:124
+#: app/templates/partials/project_details/setup_steps/step4_split.html:130
 msgid "By a regular grid"
 msgstr "按规则网格"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:125
+#: app/templates/partials/project_details/setup_steps/step4_split.html:131
 msgid "Into a fixed number of tasks"
 msgstr "按指定任务数量拆分（即将推出）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:129
+#: app/templates/partials/project_details/setup_steps/step4_split.html:135
 msgid "Cleaner shapes is disabled for this area."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:130
+#: app/templates/partials/project_details/setup_steps/step4_split.html:136
 msgid ""
 "It becomes geometrically unstable above ~5,000 features. Use the\n"
 "          faster option instead."
 msgstr ""
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:137
+#: app/templates/partials/project_details/setup_steps/step4_split.html:143
 msgid "Buildings per task"
 msgstr "每个任务平均建筑数："
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:148
+#: app/templates/partials/project_details/setup_steps/step4_split.html:154
 msgid "Number of tasks"
 msgstr "任务数量："
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:160
+#: app/templates/partials/project_details/setup_steps/step4_split.html:166
 msgid "Grid square size (metres)"
 msgstr "网格方块大小（米）"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:179
+#: app/templates/partials/project_details/setup_steps/step4_split.html:185
 msgid "Split Again"
 msgstr "重新拆分"
 
-#: app/templates/partials/project_details/setup_steps/step4_split.html:213
+#: app/templates/partials/project_details/setup_steps/step4_split.html:219
 msgid "Splitting area into tasks... This may take a moment."
 msgstr "正在将 AOI 拆分为任务……这可能需要一点时间。"
 

--- a/src/backend/app/projects/project_services.py
+++ b/src/backend/app/projects/project_services.py
@@ -24,6 +24,8 @@ exceptions (not HTTP exceptions), returning plain data structures.
 
 import json
 import logging
+import re
+import unicodedata
 from asyncio import TimeoutError as AsyncTimeoutError
 from asyncio import get_running_loop
 from dataclasses import dataclass
@@ -1162,6 +1164,162 @@ async def save_task_areas(
         f"(empty: {is_empty}, count: {task_count})"
     )
     return task_count
+
+
+# Charset matches ODK Central's dataset property name rules
+# (central_schemas.ALLOWED_PROPERTY_PATTERN), so group labels stay
+# sync-safe for the later ODK/QField assignment push PRs. Empty
+# string is allowed and means "ungrouped".
+ASSIGNED_GROUP_PATTERN = re.compile(r"^[a-zA-Z0-9_-]*$")
+ASSIGNED_GROUP_MAX_LENGTH = 100
+ASSIGNED_TO_MAX_LENGTH = 100
+
+
+def _clean_assigned_to(value: object) -> str:
+    """Stringify an assignee value and strip control/format characters."""
+    text = str(value) if value is not None else ""
+    return "".join(
+        char for char in text if unicodedata.category(char) not in ("Cc", "Cf")
+    )
+
+
+def _validate_assignment_entry(entry: object) -> dict:
+    """Validate one per-task assignment edit, returning cleaned values.
+
+    Raises:
+        ValidationError: If the entry shape or a value is invalid.
+    """
+    if not isinstance(entry, dict):
+        raise ValidationError(_("Invalid assignments data format."))
+
+    cleaned: dict[str, str] = {}
+    if "assigned_to" in entry:
+        assigned_to = _clean_assigned_to(entry["assigned_to"])
+        if len(assigned_to) > ASSIGNED_TO_MAX_LENGTH:
+            raise ValidationError(
+                _("Assignee must be %(max_length)s characters or fewer.")
+                % {"max_length": ASSIGNED_TO_MAX_LENGTH}
+            )
+        cleaned["assigned_to"] = assigned_to
+    if "assigned_group" in entry:
+        assigned_group = (
+            str(entry["assigned_group"]) if entry["assigned_group"] is not None else ""
+        )
+        if not ASSIGNED_GROUP_PATTERN.match(assigned_group):
+            raise ValidationError(
+                _(
+                    "Group labels may only contain letters, numbers, "
+                    "hyphens and underscores."
+                )
+            )
+        if len(assigned_group) > ASSIGNED_GROUP_MAX_LENGTH:
+            raise ValidationError(
+                _("Group labels must be %(max_length)s characters or fewer.")
+                % {"max_length": ASSIGNED_GROUP_MAX_LENGTH}
+            )
+        cleaned["assigned_group"] = assigned_group
+    return cleaned
+
+
+def count_assigned_tasks(task_areas: dict | None) -> int:
+    """Count stored task features carrying a non-empty assignment.
+
+    Used by the split/extract lifecycle guards to warn before actions
+    that overwrite or reset ``task_areas_geojson`` (and would silently
+    discard those assignments).
+    """
+    if not isinstance(task_areas, dict):
+        return 0
+    count = 0
+    for feature in task_areas.get("features") or []:
+        properties = feature.get("properties") or {}
+        if properties.get("assigned_to") or properties.get("assigned_group"):
+            count += 1
+    return count
+
+
+async def save_task_assignments(
+    db: AsyncConnection,
+    project_id: int,
+    assignments: dict,
+) -> int:
+    """Merge per-task assignment edits into stored task area properties.
+
+    Assignments are advisory metadata on each task feature; task ``status``
+    is owned by the field apps and is never written here.
+
+    Args:
+        db: Database connection.
+        project_id: The project ID.
+        assignments: Mapping of task id to a dict with optional
+            ``assigned_to`` / ``assigned_group`` string values.
+
+    Returns:
+        Number of task features updated.
+
+    Raises:
+        ValidationError: If the payload shape, a task id, or a value is invalid.
+    """
+    if not isinstance(assignments, dict):
+        raise ValidationError(_("Invalid assignments data format."))
+
+    # Row-lock the project so the read-merge-write below is atomic with
+    # respect to concurrent assignment saves and re-splits; without it a
+    # racing save could write a stale FeatureCollection back over edits
+    # committed in between. The lock is released by the commit below.
+    async with db.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT task_areas_geojson
+            FROM projects
+            WHERE id = %(project_id)s
+            FOR UPDATE
+            """,
+            {"project_id": project_id},
+        )
+        row = await cur.fetchone()
+    task_areas = row[0] if row else None
+    features = task_areas.get("features") if isinstance(task_areas, dict) else None
+    if not features:
+        raise ValidationError(
+            _("No task areas to assign. Split the project area into tasks first.")
+        )
+
+    # Stored task_id is authoritative (stamped by save_task_areas); stamp in
+    # memory for legacy rows saved before ids were persisted, mirroring
+    # _build_task_entities. The stamped ids then persist with this save.
+    stamp_missing_task_ids(task_areas)
+    properties_by_task_id = {
+        feature["properties"]["task_id"]: feature["properties"] for feature in features
+    }
+
+    updated_count = 0
+    for raw_task_id, entry in assignments.items():
+        try:
+            task_id = int(raw_task_id)
+        except (TypeError, ValueError) as err:
+            raise ValidationError(
+                _("Invalid task id: %(task_id)s") % {"task_id": raw_task_id}
+            ) from err
+        properties = properties_by_task_id.get(task_id)
+        if properties is None:
+            raise ValidationError(
+                _("Unknown task id: %(task_id)s") % {"task_id": task_id}
+            )
+        properties.update(_validate_assignment_entry(entry))
+        updated_count += 1
+
+    await DbProject.update(
+        db,
+        project_id,
+        project_schemas.ProjectUpdate(task_areas_geojson=task_areas),
+    )
+    await db.commit()
+
+    log.info(
+        f"Saved task assignments for project {project_id} (updated: {updated_count})"
+    )
+    return updated_count
 
 
 def _validate_odk_finalization_prereqs(

--- a/src/backend/app/projects/project_services.py
+++ b/src/backend/app/projects/project_services.py
@@ -56,6 +56,7 @@ from app.helpers.geometry_utils import (
     geojson_area_km2,
     merge_featcol_polygons_sync,
     polygon_to_centroid,
+    stamp_missing_task_ids,
 )
 from app.i18n import _
 from app.projects import project_crud, project_deps, project_schemas
@@ -1142,6 +1143,9 @@ async def save_task_areas(
     # Validate CRS if not empty
     if tasks_geojson and tasks_geojson.get("features"):
         await check_crs(tasks_geojson)
+        # Stamp stable task ids before persisting, so export builders read
+        # task identity from storage instead of re-deriving it positionally
+        stamp_missing_task_ids(tasks_geojson)
 
     await DbProject.update(
         db,
@@ -1309,14 +1313,20 @@ async def _build_task_entities(project: DbProject) -> list[dict]:
         log.info(
             f"Uploading {len(task_areas.get('features', []))} task boundaries to ODK"
         )
-        for idx, feature in enumerate(task_areas.get("features", []), start=1):
+        # Stored task_id is authoritative (stamped by save_task_areas); stamp
+        # in memory only for legacy rows saved before ids were persisted,
+        # using the same helper as the QField builder so both export paths
+        # always agree on task identity
+        stamp_missing_task_ids(task_areas)
+        for feature in task_areas.get("features", []):
             if not feature.get("geometry"):
                 continue
+            task_id = feature["properties"]["task_id"]
             entity_dict = await central_crud.feature_geojson_to_entity_dict(
                 feature,
                 additional_features=True,
             )
-            task_entities.append(_task_entity_style(entity_dict, idx))
+            task_entities.append(_task_entity_style(entity_dict, task_id))
 
     if task_entities:
         return task_entities

--- a/src/backend/app/qfield/qfield_crud.py
+++ b/src/backend/app/qfield/qfield_crud.py
@@ -53,6 +53,7 @@ from qfieldcloud_sdk.sdk import (
 
 from app.config import decrypt_value, encrypt_value, settings
 from app.db.models import DbProject
+from app.helpers.geometry_utils import stamp_missing_task_ids
 from app.i18n import _
 from app.projects.project_schemas import ProjectUpdate
 from app.qfield.qfield_deps import qfield_client
@@ -310,11 +311,10 @@ def _build_tasks_geojson(project: DbProject) -> dict:
     """
     task_areas = project.task_areas_geojson
     if task_areas and isinstance(task_areas, dict) and task_areas.get("features"):
-        for idx, feature in enumerate(task_areas["features"], start=1):
-            props = feature.setdefault("properties", {})
-            if "task_id" not in props:
-                props["task_id"] = idx
-        return task_areas
+        # Stored ids are authoritative (stamped by save_task_areas); stamping
+        # here is in-memory only, covering legacy rows saved before ids were
+        # persisted. Such projects keep derivation-based ids until re-saved.
+        return stamp_missing_task_ids(task_areas)
 
     # Fallback: single task from outline
     geometry = _extract_geometry(project.outline)

--- a/src/backend/app/static/js/task_assignment.js
+++ b/src/backend/app/static/js/task_assignment.js
@@ -1,0 +1,556 @@
+// Task assignment panel: Leaflet selection map over the stored task areas.
+//
+// Progressive enhancement on top of assignment_panel.html - the summary
+// table and save form work without this module. Edits are staged in a
+// draft diff mirrored to sessionStorage (server stays authoritative) and
+// submitted through the hidden "assignments" form field as JSON of
+// {task_id: {assigned_to, assigned_group}}. Assignments are advisory
+// metadata; task status is owned by the field apps and never written here.
+//
+// All user-visible text comes from the i18nStrings object passed in, and
+// user-supplied values (assignee names, group labels) only ever reach the
+// DOM via textContent/createTextNode - never innerHTML.
+
+import { clearContainer, renderCallout } from "./project_setup_shared.js";
+
+const UNASSIGNED_COLOR = "#ff7800";
+const GROUP_LABEL_PATTERN = /^[a-zA-Z0-9_-]*$/;
+
+let activeMap = null;
+let activeCleanup = null;
+
+function formatString(template, params) {
+  let formatted = String(template);
+  for (const [key, value] of Object.entries(params)) {
+    formatted = formatted.replace("%(" + key + ")s", String(value));
+  }
+  return formatted;
+}
+
+function colorForLabel(label) {
+  // Deterministic colour per group/assignee label so the map styling is
+  // stable across reloads without storing a palette anywhere.
+  let hash = 0;
+  for (let i = 0; i < label.length; i++) {
+    hash = (hash * 31 + label.charCodeAt(i)) | 0;
+  }
+  const hue = ((hash % 360) + 360) % 360;
+  return "hsl(" + hue + ", 70%, 40%)";
+}
+
+function destroyExistingMap(container) {
+  if (activeMap) {
+    try {
+      activeMap.remove();
+    } catch (e) {
+      // Already removed alongside its container.
+    }
+    activeMap = null;
+  }
+  if (container._leaflet_id) {
+    // Same stale-instance guard as render_leaflet_map in map_helpers.py:
+    // a previous panel render may have left a Leaflet stamp on a reused
+    // container, which would make L.map() throw "already initialized".
+    try {
+      const staleMap = L.Map.prototype.get(container._leaflet_id);
+      if (staleMap) staleMap.remove();
+    } catch (e) {
+      // No retrievable instance; fall through and clear the stamp.
+    }
+    delete container._leaflet_id;
+  }
+}
+
+export function initAssignmentPanel({ projectId, i18nStrings }) {
+  // The panel fragment can be swapped in repeatedly (htmx re-loads on
+  // navigation), so tear down any previous instance first.
+  if (activeCleanup) {
+    activeCleanup();
+    activeCleanup = null;
+  }
+
+  const savedEventName = i18nStrings.savedEvent || "assignment:saved";
+  const draftStorageKey = "ftm-draft-assignments-" + projectId;
+
+  function setUpPanel(mapContainer) {
+    const assigneeInput = document.getElementById("assignment-assignee-input");
+    const groupInput = document.getElementById("assignment-group-input");
+    const applyBtn = document.getElementById("assignment-apply-btn");
+    const unassignBtn = document.getElementById("assignment-unassign-btn");
+    const autoGroupBtn = document.getElementById("assignment-autogroup-btn");
+    const clearBtn = document.getElementById("assignment-clear-btn");
+    const payloadInput = document.getElementById("assignment-payload");
+    const messagesRegion = document.getElementById("assignment-messages");
+    const bannerRegion = document.getElementById("assignment-draft-banner");
+
+    const selectedTaskIds = new Set();
+    // taskId (string) -> {assigned_to?, assigned_group?}; only keys that
+    // differ from the server value are kept, so the draft is a pure diff.
+    let draftEdits = readDraftStorage();
+    // taskId (string) -> {assigned_to, assigned_group} as last fetched.
+    let serverProperties = {};
+    const layersByTaskId = {};
+    let taskLayer = null;
+
+    destroyExistingMap(mapContainer);
+    const map = L.map(mapContainer).setView([0, 0], 2);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      attribution: "© OSM contributors",
+      maxZoom: 19,
+    }).addTo(map);
+    activeMap = map;
+    setTimeout(function () {
+      map.invalidateSize();
+    }, 100);
+
+    function readDraftStorage() {
+      try {
+        const raw = window.sessionStorage.getItem(draftStorageKey);
+        const parsed = raw ? JSON.parse(raw) : null;
+        return parsed && typeof parsed === "object" ? parsed : {};
+      } catch (e) {
+        return {};
+      }
+    }
+
+    function writeDraftStorage() {
+      try {
+        if (Object.keys(draftEdits).length > 0) {
+          window.sessionStorage.setItem(draftStorageKey, JSON.stringify(draftEdits));
+        } else {
+          window.sessionStorage.removeItem(draftStorageKey);
+        }
+      } catch (e) {
+        // Ignore storage failures; the draft still lives in memory.
+      }
+    }
+
+    function effectiveProperties(taskId) {
+      const server = serverProperties[String(taskId)] || { assigned_to: "", assigned_group: "" };
+      return { ...server, ...(draftEdits[String(taskId)] || {}) };
+    }
+
+    function styleForTask(taskId) {
+      const props = effectiveProperties(taskId);
+      let color = UNASSIGNED_COLOR;
+      if (props.assigned_group) {
+        color = colorForLabel(props.assigned_group);
+      } else if (props.assigned_to) {
+        color = colorForLabel(props.assigned_to);
+      }
+      const selected = selectedTaskIds.has(Number(taskId));
+      return {
+        color: color,
+        weight: selected ? 6 : 3,
+        opacity: selected ? 1 : 0.8,
+        fillOpacity: selected ? 0.45 : 0.3,
+      };
+    }
+
+    function buildTaskLabel(taskId) {
+      const props = effectiveProperties(taskId);
+      const wrapper = document.createElement("div");
+      const title = document.createElement("strong");
+      title.textContent = formatString(i18nStrings.taskLabelFormat, { task_id: taskId });
+      wrapper.appendChild(title);
+      if (props.assigned_group) {
+        wrapper.appendChild(document.createElement("br"));
+        wrapper.appendChild(
+          document.createTextNode(
+            formatString(i18nStrings.groupLabelFormat, { group: props.assigned_group }),
+          ),
+        );
+      }
+      wrapper.appendChild(document.createElement("br"));
+      wrapper.appendChild(
+        document.createTextNode(
+          props.assigned_to
+            ? formatString(i18nStrings.assignedToFormat, { name: props.assigned_to })
+            : i18nStrings.unassigned,
+        ),
+      );
+      return wrapper;
+    }
+
+    function setDraftValue(taskId, key, value) {
+      const taskKey = String(taskId);
+      const server = serverProperties[taskKey] || { assigned_to: "", assigned_group: "" };
+      const entry = draftEdits[taskKey] || {};
+      if (value === server[key]) {
+        delete entry[key];
+      } else {
+        entry[key] = value;
+      }
+      if (Object.keys(entry).length > 0) {
+        draftEdits[taskKey] = entry;
+      } else {
+        delete draftEdits[taskKey];
+      }
+    }
+
+    function sanitizeDraft(rawDraft) {
+      // The draft is a diff replayed over fresh server data: entries for
+      // vanished task ids, malformed values, or values now matching the
+      // server are dropped.
+      const sanitized = {};
+      for (const [taskKey, entry] of Object.entries(rawDraft)) {
+        const server = serverProperties[taskKey];
+        if (!server || !entry || typeof entry !== "object") continue;
+        const cleaned = {};
+        if (typeof entry.assigned_to === "string" && entry.assigned_to !== server.assigned_to) {
+          cleaned.assigned_to = entry.assigned_to;
+        }
+        if (
+          typeof entry.assigned_group === "string" &&
+          GROUP_LABEL_PATTERN.test(entry.assigned_group) &&
+          entry.assigned_group !== server.assigned_group
+        ) {
+          cleaned.assigned_group = entry.assigned_group;
+        }
+        if (Object.keys(cleaned).length > 0) sanitized[taskKey] = cleaned;
+      }
+      return sanitized;
+    }
+
+    function discardDraft() {
+      draftEdits = {};
+      afterDraftChange();
+    }
+
+    function updateDraftBanner() {
+      if (!bannerRegion) return;
+      clearContainer(bannerRegion);
+      const count = Object.keys(draftEdits).length;
+      if (count === 0) return;
+      const callout = document.createElement("wa-callout");
+      callout.setAttribute("variant", "warning");
+      const span = document.createElement("span");
+      span.textContent = formatString(i18nStrings.unsavedChangesFormat, { count: count });
+      callout.appendChild(span);
+      const discardBtn = document.createElement("button");
+      discardBtn.type = "button";
+      discardBtn.className = "wa-button wa-button--default";
+      discardBtn.style.marginInlineStart = "8px";
+      discardBtn.textContent = i18nStrings.discardChanges;
+      discardBtn.addEventListener("click", discardDraft);
+      callout.appendChild(discardBtn);
+      bannerRegion.appendChild(callout);
+    }
+
+    function afterDraftChange() {
+      writeDraftStorage();
+      if (payloadInput) payloadInput.value = JSON.stringify(draftEdits);
+      updateDraftBanner();
+      restyleTaskLayers();
+    }
+
+    function restyleTaskLayers() {
+      for (const [taskKey, layer] of Object.entries(layersByTaskId)) {
+        layer.setStyle(styleForTask(Number(taskKey)));
+      }
+    }
+
+    function updateApplyButton() {
+      if (!applyBtn) return;
+      applyBtn.textContent =
+        selectedTaskIds.size > 0
+          ? formatString(i18nStrings.applyToSelectedFormat, { count: selectedTaskIds.size })
+          : i18nStrings.applyToSelected;
+    }
+
+    function syncTableCheckboxes() {
+      const checkboxes = document.querySelectorAll(".assignment-task-checkbox");
+      let allChecked = checkboxes.length > 0;
+      let anyChecked = false;
+      checkboxes.forEach(function (checkbox) {
+        const checked = selectedTaskIds.has(Number(checkbox.dataset.taskId));
+        checkbox.checked = checked;
+        allChecked = allChecked && checked;
+        anyChecked = anyChecked || checked;
+      });
+      const selectAll = document.getElementById("assignment-select-all");
+      if (selectAll) {
+        selectAll.checked = allChecked;
+        selectAll.indeterminate = anyChecked && !allChecked;
+      }
+    }
+
+    function refreshSelectionUI() {
+      restyleTaskLayers();
+      updateApplyButton();
+      syncTableCheckboxes();
+    }
+
+    function toggleSelection(taskId, extend) {
+      // Plain click replaces the selection with the clicked task (clicking
+      // the sole selected task deselects it); shift-click extends by
+      // toggling membership without clearing the rest.
+      if (extend) {
+        if (selectedTaskIds.has(taskId)) {
+          selectedTaskIds.delete(taskId);
+        } else {
+          selectedTaskIds.add(taskId);
+        }
+      } else {
+        const wasOnlySelection = selectedTaskIds.size === 1 && selectedTaskIds.has(taskId);
+        selectedTaskIds.clear();
+        if (!wasOnlySelection) selectedTaskIds.add(taskId);
+      }
+      refreshSelectionUI();
+    }
+
+    function enhanceSummaryTable() {
+      // Add a selection checkbox column to the server-rendered summary
+      // table; map and table share the same selection set. The table is
+      // re-rendered by the save POST, so this runs again after each swap.
+      const table = document.getElementById("assignment-summary-table");
+      if (!table || table.dataset.selectionEnhanced) return;
+      table.dataset.selectionEnhanced = "true";
+
+      const headerRow = table.querySelector("thead tr");
+      if (headerRow) {
+        const th = document.createElement("th");
+        th.style.padding = "6px 8px";
+        const selectAll = document.createElement("input");
+        selectAll.type = "checkbox";
+        selectAll.id = "assignment-select-all";
+        selectAll.setAttribute("aria-label", i18nStrings.selectAllTasks);
+        selectAll.addEventListener("change", function () {
+          table.querySelectorAll(".assignment-task-checkbox").forEach(function (checkbox) {
+            const taskId = Number(checkbox.dataset.taskId);
+            if (selectAll.checked) {
+              selectedTaskIds.add(taskId);
+            } else {
+              selectedTaskIds.delete(taskId);
+            }
+          });
+          refreshSelectionUI();
+        });
+        th.appendChild(selectAll);
+        headerRow.insertBefore(th, headerRow.firstElementChild);
+      }
+
+      table.querySelectorAll("tbody tr[data-task-id]").forEach(function (row) {
+        const taskId = Number(row.dataset.taskId);
+        if (!Number.isFinite(taskId)) return;
+        const td = document.createElement("td");
+        td.style.padding = "6px 8px";
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.className = "assignment-task-checkbox";
+        checkbox.dataset.taskId = String(taskId);
+        checkbox.setAttribute(
+          "aria-label",
+          formatString(i18nStrings.selectTaskFormat, { task_id: taskId }),
+        );
+        checkbox.addEventListener("change", function () {
+          if (checkbox.checked) {
+            selectedTaskIds.add(taskId);
+          } else {
+            selectedTaskIds.delete(taskId);
+          }
+          refreshSelectionUI();
+        });
+        td.appendChild(checkbox);
+        row.insertBefore(td, row.firstElementChild);
+      });
+
+      syncTableCheckboxes();
+    }
+
+    function renderTaskLayer(featureCollection) {
+      if (taskLayer) {
+        map.removeLayer(taskLayer);
+        taskLayer = null;
+      }
+      for (const taskKey of Object.keys(layersByTaskId)) {
+        delete layersByTaskId[taskKey];
+      }
+
+      serverProperties = {};
+      (featureCollection.features || []).forEach(function (feature) {
+        const props = feature.properties || {};
+        if (props.task_id === undefined || props.task_id === null) return;
+        serverProperties[String(props.task_id)] = {
+          assigned_to: typeof props.assigned_to === "string" ? props.assigned_to : "",
+          assigned_group: typeof props.assigned_group === "string" ? props.assigned_group : "",
+        };
+      });
+      draftEdits = sanitizeDraft(draftEdits);
+      Array.from(selectedTaskIds).forEach(function (taskId) {
+        if (!serverProperties[String(taskId)]) selectedTaskIds.delete(taskId);
+      });
+
+      taskLayer = L.geoJSON(featureCollection, {
+        style: function (feature) {
+          return styleForTask((feature.properties || {}).task_id);
+        },
+        onEachFeature: function (feature, layer) {
+          const taskId = (feature.properties || {}).task_id;
+          if (taskId === undefined || taskId === null) return;
+          layersByTaskId[String(taskId)] = layer;
+          layer.on("click", function (event) {
+            toggleSelection(Number(taskId), Boolean(event.originalEvent && event.originalEvent.shiftKey));
+          });
+          // Content function so the label reflects draft edits when shown.
+          layer.bindTooltip(
+            function () {
+              return buildTaskLabel(taskId);
+            },
+            { sticky: true },
+          );
+        },
+      }).addTo(map);
+
+      if (taskLayer.getBounds().isValid()) {
+        map.fitBounds(taskLayer.getBounds());
+      }
+      afterDraftChange();
+      refreshSelectionUI();
+    }
+
+    function loadTaskAreas() {
+      return fetch("/projects/" + projectId + "/assignments/geojson")
+        .then(function (response) {
+          if (!response.ok) throw new Error("HTTP " + response.status);
+          return response.json();
+        })
+        .then(function (featureCollection) {
+          renderTaskLayer(featureCollection);
+        })
+        .catch(function () {
+          renderCallout(messagesRegion, "danger", i18nStrings.loadFailed);
+        });
+    }
+
+    function applyToSelected() {
+      clearContainer(messagesRegion);
+      if (selectedTaskIds.size === 0) {
+        renderCallout(messagesRegion, "warning", i18nStrings.noSelection);
+        return;
+      }
+      const group = groupInput ? groupInput.value.trim() : "";
+      if (!GROUP_LABEL_PATTERN.test(group)) {
+        renderCallout(messagesRegion, "danger", i18nStrings.invalidGroupLabel);
+        return;
+      }
+      const assignee = assigneeInput ? assigneeInput.value.trim() : "";
+      if (!assignee && !group) {
+        renderCallout(messagesRegion, "warning", i18nStrings.nothingToApply);
+        return;
+      }
+      // Only stage the fields the user actually filled in, so applying a
+      // group label alone never silently clears existing assignees;
+      // intentional clearing goes through "Unassign selected" instead.
+      selectedTaskIds.forEach(function (taskId) {
+        if (assignee) setDraftValue(taskId, "assigned_to", assignee);
+        if (group) setDraftValue(taskId, "assigned_group", group);
+      });
+      afterDraftChange();
+    }
+
+    function unassignSelected() {
+      // Explicit clear affordance: stages empty assignee and group for the
+      // selection ("" means unassigned/ungrouped on the server).
+      clearContainer(messagesRegion);
+      if (selectedTaskIds.size === 0) {
+        renderCallout(messagesRegion, "warning", i18nStrings.noSelection);
+        return;
+      }
+      selectedTaskIds.forEach(function (taskId) {
+        setDraftValue(taskId, "assigned_to", "");
+        setDraftValue(taskId, "assigned_group", "");
+      });
+      afterDraftChange();
+    }
+
+    function autoGroupByQuadrant() {
+      // Bucket every task into NE/NW/SE/SW by where its bounds centre
+      // falls relative to the bbox centre of the whole task layer.
+      if (!taskLayer || !taskLayer.getBounds().isValid()) return;
+      clearContainer(messagesRegion);
+      const center = taskLayer.getBounds().getCenter();
+      for (const [taskKey, layer] of Object.entries(layersByTaskId)) {
+        const taskCenter = layer.getBounds ? layer.getBounds().getCenter() : layer.getLatLng();
+        if (!taskCenter) continue;
+        const quadrant =
+          (taskCenter.lat >= center.lat ? "N" : "S") + (taskCenter.lng >= center.lng ? "E" : "W");
+        setDraftValue(taskKey, "assigned_group", quadrant);
+      }
+      afterDraftChange();
+    }
+
+    if (applyBtn) applyBtn.addEventListener("click", applyToSelected);
+    if (unassignBtn) unassignBtn.addEventListener("click", unassignSelected);
+    if (autoGroupBtn) autoGroupBtn.addEventListener("click", autoGroupByQuadrant);
+    if (clearBtn) {
+      clearBtn.addEventListener("click", function () {
+        selectedTaskIds.clear();
+        refreshSelectionUI();
+      });
+    }
+
+    function onSaved(event) {
+      const detail = event.detail || {};
+      if (detail.projectId !== undefined && Number(detail.projectId) !== Number(projectId)) {
+        return;
+      }
+      // Server is authoritative again: drop the draft and re-fetch.
+      draftEdits = {};
+      afterDraftChange();
+      loadTaskAreas();
+    }
+
+    function onSummarySwap(event) {
+      if (event.target && event.target.id === "assignment-summary-region") {
+        enhanceSummaryTable();
+      }
+    }
+
+    document.body.addEventListener(savedEventName, onSaved);
+    document.body.addEventListener("htmx:afterSwap", onSummarySwap);
+
+    activeCleanup = function () {
+      document.body.removeEventListener(savedEventName, onSaved);
+      document.body.removeEventListener("htmx:afterSwap", onSummarySwap);
+      try {
+        map.remove();
+      } catch (e) {
+        // Already removed alongside its container.
+      }
+      if (activeMap === map) activeMap = null;
+    };
+
+    enhanceSummaryTable();
+    updateApplyButton();
+    if (payloadInput) payloadInput.value = JSON.stringify(draftEdits);
+    loadTaskAreas();
+  }
+
+  // Deferred init per render_leaflet_map in map_helpers.py: wait for the
+  // container to be swapped into the DOM and for the Leaflet global.
+  function start() {
+    const mapContainer = document.getElementById("assignment-map");
+    if (!mapContainer) return;
+    if (typeof L === "undefined") {
+      setTimeout(start, 100);
+      return;
+    }
+    setUpPanel(mapContainer);
+  }
+
+  if (document.getElementById("assignment-map")) {
+    start();
+  } else {
+    const onPanelSwap = function () {
+      if (document.getElementById("assignment-map")) {
+        document.body.removeEventListener("htmx:afterSwap", onPanelSwap);
+        start();
+      }
+    };
+    document.body.addEventListener("htmx:afterSwap", onPanelSwap);
+    activeCleanup = function () {
+      document.body.removeEventListener("htmx:afterSwap", onPanelSwap);
+    };
+  }
+}

--- a/src/backend/app/static/js/task_assignment.js
+++ b/src/backend/app/static/js/task_assignment.js
@@ -390,7 +390,10 @@ export function initAssignmentPanel({ projectId, i18nStrings }) {
           if (taskId === undefined || taskId === null) return;
           layersByTaskId[String(taskId)] = layer;
           layer.on("click", function (event) {
-            toggleSelection(Number(taskId), Boolean(event.originalEvent && event.originalEvent.shiftKey));
+            toggleSelection(
+              Number(taskId),
+              Boolean(event.originalEvent && event.originalEvent.shiftKey),
+            );
           });
           // Content function so the label reflects draft edits when shown.
           layer.bindTooltip(

--- a/src/backend/app/templates/partials/project_details/fragments/assignment_panel.html
+++ b/src/backend/app/templates/partials/project_details/fragments/assignment_panel.html
@@ -1,0 +1,144 @@
+<!-- Task assignment panel (project managers). Assignments are advisory
+     feature properties on the stored task areas; task status stays owned
+     by the field apps. The map/selection behaviour is progressive
+     enhancement - the summary table and save form work without JS. -->
+{% if not has_task_areas %}
+<wa-callout variant="info">
+  <span
+    >{{ _("This project has a single task covering the whole area. Split the area into tasks to
+    assign mappers to specific task areas.") }}</span
+  >
+</wa-callout>
+{% else %}
+<div id="assignment-panel-content">
+  <h3 class="ftm-step__title">{{ _("Task Assignments") }}</h3>
+  <p class="ftm-step-intro">
+    {{ _("Select tasks on the map, then apply an assignee and group label. Changes are saved when
+    you press Save assignments.") }}
+  </p>
+
+  <div id="assignment-map" style="height: 400px; margin-bottom: 15px"></div>
+
+  <div class="ftm-split-grid" style="margin-bottom: 10px">
+    <div>
+      <label for="assignment-assignee-input" class="ftm-split-label">{{ _("Assignee") }}</label>
+      <input
+        type="text"
+        id="assignment-assignee-input"
+        list="assignment-assignee-options"
+        maxlength="100"
+        class="ftm-split-input"
+        placeholder="{{ _('Mapper name (free text)') }}"
+      />
+      <!-- QFC collaborator suggestions for QField projects; ODK projects
+           get free text only. Free-text entry is always allowed. -->
+      <datalist id="assignment-assignee-options">
+        {% for name in assignee_suggestions %}
+        <option value="{{ name }}"></option>
+        {% endfor %}
+      </datalist>
+    </div>
+    <div>
+      <label for="assignment-group-input" class="ftm-split-label">{{ _("Group label") }}</label>
+      <input
+        type="text"
+        id="assignment-group-input"
+        pattern="[a-zA-Z0-9_-]*"
+        maxlength="100"
+        class="ftm-split-input"
+        placeholder="{{ _('e.g. NE') }}"
+      />
+    </div>
+  </div>
+  <div class="ftm-step__actions" style="margin-top: 0; margin-bottom: 8px">
+    <button id="assignment-apply-btn" type="button" class="wa-button wa-button--default">
+      {{ _("Apply to selected") }}
+    </button>
+    <button id="assignment-autogroup-btn" type="button" class="wa-button wa-button--default">
+      {{ _("Auto-group by quadrant") }}
+    </button>
+    <button id="assignment-unassign-btn" type="button" class="wa-button wa-button--default">
+      {{ _("Unassign selected") }}
+    </button>
+    <button id="assignment-clear-btn" type="button" class="wa-button wa-button--default">
+      {{ _("Clear selection") }}
+    </button>
+  </div>
+
+  <!-- Filled by the JS module: transient validation messages and the
+       restored-draft "N unsaved changes" banner. -->
+  <div id="assignment-messages" style="margin-bottom: 8px"></div>
+  <div id="assignment-draft-banner" style="margin-bottom: 8px"></div>
+
+  <!-- On 4xx/5xx the global htmx config would swap the error callout over
+       the summary table; suppress that (split_running.html pattern) and
+       surface the server-rendered error in the messages region instead. -->
+  <form
+    id="assignment-save-form"
+    hx-post="/projects/{{ project_id }}/assignments"
+    hx-target="#assignment-summary-region"
+    hx-swap="innerHTML"
+    hx-indicator="#assignment-save-indicator"
+    hx-on::before-swap="if (event.detail.xhr.status >= 400) { event.detail.shouldSwap = false; event.detail.isError = false; const region = document.getElementById('assignment-messages'); if (region) { region.innerHTML = event.detail.serverResponse; } }"
+  >
+    <input type="hidden" id="assignment-payload" name="assignments" value="{}" />
+    <button
+      type="submit"
+      class="wa-button wa-button--brand"
+      style="min-width: 180px; position: relative"
+    >
+      {{ _("Save assignments") }}
+      <span
+        id="assignment-save-indicator"
+        class="htmx-indicator"
+        style="display: none; margin-inline-start: 8px"
+      >
+        <svg
+          class="ftm-spinner"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path d="M21 12a9 9 0 11-6.219-8.56" />
+        </svg>
+      </span>
+    </button>
+  </form>
+
+  <div id="assignment-summary-region">
+    {% include "partials/project_details/fragments/assignment_summary.html" %}
+  </div>
+
+  <script>
+    (function () {
+      const projectId = {{ project_id }};
+      const i18nStrings = {
+        unassigned: {{ _("Unassigned")|tojson }},
+        taskLabelFormat: {{ _("Task %(task_id)s")|tojson }},
+        groupLabelFormat: {{ _("Group: %(group)s")|tojson }},
+        assignedToFormat: {{ _("Assigned to: %(name)s")|tojson }},
+        applyToSelectedFormat: {{ _("Apply to selected (%(count)s)")|tojson }},
+        applyToSelected: {{ _("Apply to selected")|tojson }},
+        noSelection: {{ _("Select one or more tasks on the map first.")|tojson }},
+        nothingToApply: {{ _("Enter an assignee or group label to apply first.")|tojson }},
+        unsavedChangesFormat: {{ _("%(count)s unsaved changes")|tojson }},
+        discardChanges: {{ _("Discard changes")|tojson }},
+        invalidGroupLabel: {{ _("Group labels may only contain letters, numbers, hyphens and underscores.")|tojson }},
+        loadFailed: {{ _("Could not load task areas.")|tojson }},
+        selectAllTasks: {{ _("Select all tasks")|tojson }},
+        selectTaskFormat: {{ _("Select task %(task_id)s")|tojson }},
+        savedEvent: 'assignment:saved',
+      };
+      import('/static/js/task_assignment.js')
+        .then(({ initAssignmentPanel }) => {
+          initAssignmentPanel({ projectId, i18nStrings });
+        })
+        .catch(() => {
+          // The summary table and save form stay usable even if the
+          // optional map module fails to load.
+        });
+    })();
+  </script>
+</div>
+{% endif %}

--- a/src/backend/app/templates/partials/project_details/fragments/assignment_summary.html
+++ b/src/backend/app/templates/partials/project_details/fragments/assignment_summary.html
@@ -1,0 +1,36 @@
+<!-- Server-rendered assignment summary, re-rendered by the save POST.
+     Values are user-supplied free text and rely on Jinja autoescaping. -->
+{% if saved_message %}
+<wa-callout variant="success">
+  <span>{{ saved_message }}</span>
+</wa-callout>
+{% endif %} {% if has_task_areas %}
+<table id="assignment-summary-table" style="width: 100%; margin-top: 10px; border-collapse: collapse">
+  <thead>
+    <tr style="text-align: start; border-bottom: 1px solid #ddd">
+      <th style="text-align: start; padding: 6px 8px">{{ _("Task") }}</th>
+      <th style="text-align: start; padding: 6px 8px">{{ _("Group") }}</th>
+      <th style="text-align: start; padding: 6px 8px">{{ _("Assignee") }}</th>
+      {% if has_building_counts %}
+      <th style="text-align: start; padding: 6px 8px">{{ _("Buildings") }}</th>
+      {% endif %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in summary_rows %}
+    <tr style="border-bottom: 1px solid #eee" data-task-id="{{ row.task_id }}">
+      <td style="padding: 6px 8px">{{ row.task_id }}</td>
+      <td style="padding: 6px 8px">{{ row.assigned_group }}</td>
+      <td style="padding: 6px 8px">
+        {% if row.assigned_to %}{{ row.assigned_to }}{% else %}
+        <span style="color: #666">{{ _("Unassigned") }}</span>
+        {% endif %}
+      </td>
+      {% if has_building_counts %}
+      <td style="padding: 6px 8px">{{ row.building_count if row.building_count is not none }}</td>
+      {% endif %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}

--- a/src/backend/app/templates/partials/project_details/fragments/assignment_summary.html
+++ b/src/backend/app/templates/partials/project_details/fragments/assignment_summary.html
@@ -5,7 +5,10 @@
   <span>{{ saved_message }}</span>
 </wa-callout>
 {% endif %} {% if has_task_areas %}
-<table id="assignment-summary-table" style="width: 100%; margin-top: 10px; border-collapse: collapse">
+<table
+  id="assignment-summary-table"
+  style="width: 100%; margin-top: 10px; border-collapse: collapse"
+>
   <thead>
     <tr style="text-align: start; border-bottom: 1px solid #ddd">
       <th style="text-align: start; padding: 6px 8px">{{ _("Task") }}</th>

--- a/src/backend/app/templates/partials/project_details/fragments/split_preview.html
+++ b/src/backend/app/templates/partials/project_details/fragments/split_preview.html
@@ -21,9 +21,14 @@
         hx-target="#split-status"
         hx-swap="innerHTML"
         hx-include="#accept-split-form"
-        {% if discard_assignment_count %}
+        {%
+        if
+        discard_assignment_count
+        %}
         hx-confirm="{{ _('Accepting this split discards %(count)s existing task assignment(s). Continue?') % {'count': discard_assignment_count} }}"
-        {% endif %}
+        {%
+        endif
+        %}
         class="wa-button wa-button--primary"
         style="min-width: 200px"
       >

--- a/src/backend/app/templates/partials/project_details/fragments/split_preview.html
+++ b/src/backend/app/templates/partials/project_details/fragments/split_preview.html
@@ -21,6 +21,9 @@
         hx-target="#split-status"
         hx-swap="innerHTML"
         hx-include="#accept-split-form"
+        {% if discard_assignment_count %}
+        hx-confirm="{{ _('Accepting this split discards %(count)s existing task assignment(s). Continue?') % {'count': discard_assignment_count} }}"
+        {% endif %}
         class="wa-button wa-button--primary"
         style="min-width: 200px"
       >

--- a/src/backend/app/templates/partials/project_details/setup_steps.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps.html
@@ -12,10 +12,11 @@ project.task_areas_geojson is not none %} {% set is_no_splitting = project.task_
 overwrites/resets task_areas_geojson, so the destructive actions below confirm first when this is
 non-zero (assignment lifecycle guard). #} {% set assigned_ns = namespace(count=0) %} {% if
 has_task_areas and not is_no_splitting %} {% for feature in
-(project.task_areas_geojson.get('features') or []) %} {% set feature_props = feature.get('properties')
-or {} %} {% if feature_props.get('assigned_to') or feature_props.get('assigned_group') %} {% set
-assigned_ns.count = assigned_ns.count + 1 %} {% endif %} {% endfor %} {% endif %} {% set
-assigned_task_count = assigned_ns.count %} {% if status_value == 'PUBLISHED' %}
+(project.task_areas_geojson.get('features') or []) %} {% set feature_props =
+feature.get('properties') or {} %} {% if feature_props.get('assigned_to') or
+feature_props.get('assigned_group') %} {% set assigned_ns.count = assigned_ns.count + 1 %} {% endif
+%} {% endfor %} {% endif %} {% set assigned_task_count = assigned_ns.count %} {% if status_value ==
+'PUBLISHED' %}
 <!-- Project Published - Mapper-first access -->
 <div class="ftm-published-divider ftm-published-divider--top">
   <h2 class="ftm-published-header">{{ _("Ready for Mapping") }}</h2>
@@ -44,9 +45,7 @@ assigned_task_count = assigned_ns.count %} {% if status_value == 'PUBLISHED' %}
       <p style="color: #666">{{ _("Loading collaborator form...") }}</p>
     </div>
   </div>
-  {% endif %}
-
-  {% if show_assignment_panel %}
+  {% endif %} {% if show_assignment_panel %}
   <div
     id="assignment-panel"
     hx-get="/projects/{{ project.id }}/assignments-htmx"

--- a/src/backend/app/templates/partials/project_details/setup_steps.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps.html
@@ -8,7 +8,14 @@ project.data_extract_geojson.get('type') == 'FeatureCollection' and
 project.data_extract_geojson.get('features') is not none and
 project.data_extract_geojson.get('features') | length == 0) %} {% set has_task_areas =
 project.task_areas_geojson is not none %} {% set is_no_splitting = project.task_areas_geojson == {}
-%} {% if status_value == 'PUBLISHED' %}
+%} {# Count stored task features carrying assignments: re-splitting or replacing the data extract
+overwrites/resets task_areas_geojson, so the destructive actions below confirm first when this is
+non-zero (assignment lifecycle guard). #} {% set assigned_ns = namespace(count=0) %} {% if
+has_task_areas and not is_no_splitting %} {% for feature in
+(project.task_areas_geojson.get('features') or []) %} {% set feature_props = feature.get('properties')
+or {} %} {% if feature_props.get('assigned_to') or feature_props.get('assigned_group') %} {% set
+assigned_ns.count = assigned_ns.count + 1 %} {% endif %} {% endfor %} {% endif %} {% set
+assigned_task_count = assigned_ns.count %} {% if status_value == 'PUBLISHED' %}
 <!-- Project Published - Mapper-first access -->
 <div class="ftm-published-divider ftm-published-divider--top">
   <h2 class="ftm-published-header">{{ _("Ready for Mapping") }}</h2>
@@ -36,6 +43,17 @@ project.task_areas_geojson is not none %} {% set is_no_splitting = project.task_
     <div class="ftm-qfc-collab__loading">
       <p style="color: #666">{{ _("Loading collaborator form...") }}</p>
     </div>
+  </div>
+  {% endif %}
+
+  {% if show_assignment_panel %}
+  <div
+    id="assignment-panel"
+    hx-get="/projects/{{ project.id }}/assignments-htmx"
+    hx-trigger="load"
+    hx-swap="innerHTML"
+  >
+    <wa-spinner style="font-size: 32px"></wa-spinner>
   </div>
   {% endif %}
 </div>

--- a/src/backend/app/templates/partials/project_details/setup_steps/step3_data.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step3_data.html
@@ -22,6 +22,9 @@
       hx-target="#osm-data-status"
       hx-swap="innerHTML"
       hx-indicator="#download-spinner"
+      {% if assigned_task_count %}
+      hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
+      {% endif %}
       class="wa-button wa-button--brand"
       style="min-width: 200px; position: relative"
     >
@@ -48,6 +51,9 @@
       hx-post="/collect-new-data-only-htmx?project_id={% if project %}{{ project.id }}{% endif %}"
       hx-target="#osm-data-status"
       hx-swap="innerHTML"
+      {% if assigned_task_count %}
+      hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
+      {% endif %}
       class="wa-button wa-button--default"
       style="min-width: 200px"
     >
@@ -153,6 +159,9 @@
     hx-target="#osm-data-status"
     hx-swap="innerHTML"
     hx-encoding="multipart/form-data"
+    {% if assigned_task_count %}
+    hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
+    {% endif %}
     style="display: none"
   >
     <input type="file" name="data" id="geojson-file-input" accept=".geojson,.json" required />

--- a/src/backend/app/templates/partials/project_details/setup_steps/step3_data.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step3_data.html
@@ -22,9 +22,14 @@
       hx-target="#osm-data-status"
       hx-swap="innerHTML"
       hx-indicator="#download-spinner"
-      {% if assigned_task_count %}
+      {%
+      if
+      assigned_task_count
+      %}
       hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
-      {% endif %}
+      {%
+      endif
+      %}
       class="wa-button wa-button--brand"
       style="min-width: 200px; position: relative"
     >
@@ -51,9 +56,14 @@
       hx-post="/collect-new-data-only-htmx?project_id={% if project %}{{ project.id }}{% endif %}"
       hx-target="#osm-data-status"
       hx-swap="innerHTML"
-      {% if assigned_task_count %}
+      {%
+      if
+      assigned_task_count
+      %}
       hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
-      {% endif %}
+      {%
+      endif
+      %}
       class="wa-button wa-button--default"
       style="min-width: 200px"
     >
@@ -159,9 +169,14 @@
     hx-target="#osm-data-status"
     hx-swap="innerHTML"
     hx-encoding="multipart/form-data"
-    {% if assigned_task_count %}
+    {%
+    if
+    assigned_task_count
+    %}
     hx-confirm="{{ _('Replacing the data extract discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
-    {% endif %}
+    {%
+    endif
+    %}
     style="display: none"
   >
     <input type="file" name="data" id="geojson-file-input" accept=".geojson,.json" required />

--- a/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
@@ -23,6 +23,9 @@ if has_task_areas %}
       hx-post="/skip-task-split-htmx?project_id={% if project %}{{ project.id }}{% endif %}&mode=fragment"
       hx-target="#split-status"
       hx-swap="innerHTML"
+      {% if assigned_task_count %}
+      hx-confirm="{{ _('This will discard %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
+      {% endif %}
       class="wa-button wa-button--default"
       style="min-width: 120px"
     >
@@ -42,6 +45,9 @@ if has_task_areas %}
     hx-target="#split-status"
     hx-swap="innerHTML"
     hx-indicator="#split-loading"
+    {% if assigned_task_count %}
+    hx-confirm="{{ _('Re-splitting discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
+    {% endif %}
     style="margin-bottom: 15px"
   >
     <div id="split-advanced-config-panel" class="ftm-advanced-config ftm-advanced-config--hidden">

--- a/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
@@ -23,9 +23,14 @@ if has_task_areas %}
       hx-post="/skip-task-split-htmx?project_id={% if project %}{{ project.id }}{% endif %}&mode=fragment"
       hx-target="#split-status"
       hx-swap="innerHTML"
-      {% if assigned_task_count %}
+      {%
+      if
+      assigned_task_count
+      %}
       hx-confirm="{{ _('This will discard %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
-      {% endif %}
+      {%
+      endif
+      %}
       class="wa-button wa-button--default"
       style="min-width: 120px"
     >
@@ -45,9 +50,14 @@ if has_task_areas %}
     hx-target="#split-status"
     hx-swap="innerHTML"
     hx-indicator="#split-loading"
-    {% if assigned_task_count %}
+    {%
+    if
+    assigned_task_count
+    %}
     hx-confirm="{{ _('Re-splitting discards %(count)s existing task assignment(s). Continue?') % {'count': assigned_task_count} }}"
-    {% endif %}
+    {%
+    endif
+    %}
     style="margin-bottom: 15px"
   >
     <div id="split-advanced-config-panel" class="ftm-advanced-config ftm-advanced-config--hidden">

--- a/src/backend/tests/htmx/test_assignment_routes.py
+++ b/src/backend/tests/htmx/test_assignment_routes.py
@@ -1,0 +1,444 @@
+"""Tests for the task assignment HTMX routes."""
+
+import json
+from unittest.mock import Mock
+
+from litestar import Router
+from litestar import status_codes as status
+
+from app.db.enums import ProjectStatus
+from app.db.models import DbProject
+from app.htmx.assignment import assignment_routes
+from app.htmx.assignment.assignment_routes import (
+    assignment_geojson,
+    assignment_panel_htmx,
+    save_assignments_htmx,
+)
+
+# Two small task polygons inside the Kathmandu test outline. task_id is
+# pre-stamped (save_task_areas would normally do this on accept-split).
+_TASK_AREAS = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [85.3000, 27.7110],
+                        [85.3000, 27.7125],
+                        [85.3020, 27.7125],
+                        [85.3020, 27.7110],
+                        [85.3000, 27.7110],
+                    ]
+                ],
+            },
+            "properties": {"task_id": 1, "building_count": 12},
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [85.3020, 27.7110],
+                        [85.3020, 27.7125],
+                        [85.3040, 27.7125],
+                        [85.3040, 27.7110],
+                        [85.3020, 27.7110],
+                    ]
+                ],
+            },
+            "properties": {"task_id": 2},
+        },
+    ],
+}
+
+
+async def _set_task_areas(db, project_id, task_areas):
+    """Persist task areas (or the {} no-split sentinel) on the project."""
+    await DbProject.update(
+        db,
+        project_id,
+        DbProject(task_areas_geojson=task_areas),
+    )
+    await db.commit()
+
+
+def test_assignment_routes_are_registered():
+    """All assignment handlers must be exported to the router."""
+    assert assignment_panel_htmx in assignment_routes.ROUTE_HANDLERS
+    assert assignment_geojson in assignment_routes.ROUTE_HANDLERS
+    assert save_assignments_htmx in assignment_routes.ROUTE_HANDLERS
+
+
+def test_assignment_routes_register_with_litestar():
+    """Assignment route exports must be decorated route handlers."""
+    Router(path="/", route_handlers=assignment_routes.ROUTE_HANDLERS)
+
+
+async def test_assignment_panel_renders_map_and_summary(client, db, project):
+    """The panel fragment should include the map slot, save form and table."""
+    task_areas = json.loads(json.dumps(_TASK_AREAS))
+    task_areas["features"][0]["properties"]["assigned_to"] = "alice"
+    task_areas["features"][0]["properties"]["assigned_group"] = "NE"
+    await _set_task_areas(db, project.id, task_areas)
+
+    response = await client.get(
+        f"/projects/{project.id}/assignments-htmx",
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'id="assignment-map"' in response.text
+    assert 'id="assignment-save-form"' in response.text
+    assert f'hx-post="/projects/{project.id}/assignments"' in response.text
+    assert 'name="assignments"' in response.text
+    assert "Save assignments" in response.text
+    assert "alice" in response.text
+    assert "NE" in response.text
+    assert "Unassigned" in response.text
+    assert "/static/js/task_assignment.js" in response.text
+
+
+async def test_assignment_panel_shows_no_split_callout(client, db, project):
+    """The {} no-split sentinel should render an explanatory callout."""
+    await _set_task_areas(db, project.id, {})
+
+    response = await client.get(
+        f"/projects/{project.id}/assignments-htmx",
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "single task covering the whole area" in response.text
+    assert 'id="assignment-map"' not in response.text
+
+
+async def test_assignment_panel_escapes_user_supplied_assignee(client, db, project):
+    """Summary table must autoescape free-text assignee values."""
+    task_areas = json.loads(json.dumps(_TASK_AREAS))
+    task_areas["features"][0]["properties"]["assigned_to"] = "<script>boom</script>"
+    await _set_task_areas(db, project.id, task_areas)
+
+    response = await client.get(
+        f"/projects/{project.id}/assignments-htmx",
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "<script>boom</script>" not in response.text
+    assert "&lt;script&gt;boom&lt;/script&gt;" in response.text
+
+
+async def test_assignment_panel_requires_project_context():
+    """The panel should return 404 when the project context is missing."""
+    response = await assignment_panel_htmx.fn(
+        request=Mock(),
+        current_user={"project": None},
+        auth_user=Mock(),
+        project_id=123,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_assignment_geojson_merges_assignment_properties(client, db, project):
+    """The geojson endpoint should return stored features with defaults merged."""
+    task_areas = json.loads(json.dumps(_TASK_AREAS))
+    task_areas["features"][0]["properties"]["assigned_to"] = "alice"
+    await _set_task_areas(db, project.id, task_areas)
+
+    response = await client.get(f"/projects/{project.id}/assignments/geojson")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers["content-type"].startswith("application/geo+json")
+    feature_collection = response.json()
+    assert feature_collection["type"] == "FeatureCollection"
+    features = feature_collection["features"]
+    assert len(features) == 2
+    by_task_id = {f["properties"]["task_id"]: f["properties"] for f in features}
+    assert by_task_id[1]["assigned_to"] == "alice"
+    assert by_task_id[1]["assigned_group"] == ""
+    assert by_task_id[1]["building_count"] == 12
+    assert by_task_id[2]["assigned_to"] == ""
+    assert by_task_id[2]["assigned_group"] == ""
+
+
+async def test_assignment_routes_handle_legacy_task_ids(client, db, project):
+    """Legacy rows saved before id stamping must get usable integer ids.
+
+    Digit-string ids are normalized and missing ids stamped in memory on
+    the read paths, and persisted by the save path, so the panel renders
+    and saves succeed for projects predating save_task_areas stamping.
+    """
+    task_areas = json.loads(json.dumps(_TASK_AREAS))
+    task_areas["features"][0]["properties"] = {"task_id": "3"}
+    task_areas["features"][1]["properties"] = {}
+    await _set_task_areas(db, project.id, task_areas)
+
+    panel_response = await client.get(
+        f"/projects/{project.id}/assignments-htmx",
+        headers={"HX-Request": "true"},
+    )
+    assert panel_response.status_code == status.HTTP_200_OK
+    assert 'id="assignment-summary-table"' in panel_response.text
+
+    geojson_response = await client.get(f"/projects/{project.id}/assignments/geojson")
+    assert geojson_response.status_code == status.HTTP_200_OK
+    task_ids = [
+        feature["properties"]["task_id"]
+        for feature in geojson_response.json()["features"]
+    ]
+    assert task_ids == [3, 1]
+
+    save_response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"3": {"assigned_to": "alice"}})},
+        headers={"HX-Request": "true"},
+    )
+    assert save_response.status_code == status.HTTP_200_OK
+
+    updated_project = await DbProject.one(db, project.id)
+    by_task_id = {
+        f["properties"]["task_id"]: f["properties"]
+        for f in updated_project.task_areas_geojson["features"]
+    }
+    # The in-memory stamping persisted with the save: unique integer ids
+    assert set(by_task_id) == {1, 3}
+    assert by_task_id[3]["assigned_to"] == "alice"
+
+
+async def test_assignment_panel_renders_assignee_suggestions(
+    client, db, project, monkeypatch
+):
+    """QFC collaborator suggestions should render as datalist options."""
+
+    async def fake_suggestions(_project):
+        return ["alice", "bob"]
+
+    monkeypatch.setattr(
+        assignment_routes, "_qfc_assignee_suggestions", fake_suggestions
+    )
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.get(
+        f"/projects/{project.id}/assignments-htmx",
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'id="assignment-assignee-options"' in response.text
+    assert '<option value="alice"></option>' in response.text
+    assert '<option value="bob"></option>' in response.text
+
+
+async def test_assignment_geojson_404_for_no_split_sentinel(client, db, project):
+    """The {} sentinel has no features to assign, so the endpoint 404s."""
+    await _set_task_areas(db, project.id, {})
+
+    response = await client.get(f"/projects/{project.id}/assignments/geojson")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "error" in response.json()
+
+
+async def test_assignment_geojson_requires_project_context():
+    """The geojson endpoint should return a JSON 404 without project context."""
+    response = await assignment_geojson.fn(
+        request=Mock(),
+        current_user={"project": None},
+        auth_user=Mock(),
+        project_id=123,
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "error" in json.loads(response.content)
+
+
+async def test_save_assignments_happy_path(client, db, project):
+    """Saving valid assignments should persist and return the summary."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={
+            "assignments": json.dumps(
+                {
+                    "1": {"assigned_to": "alice", "assigned_group": "NE"},
+                    "2": {"assigned_to": "bob", "assigned_group": "SW"},
+                }
+            )
+        },
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    hx_trigger = json.loads(response.headers.get("HX-Trigger", "{}"))
+    trigger_payload = hx_trigger.get("assignment:saved")
+    assert trigger_payload is not None
+    assert trigger_payload["projectId"] == project.id
+    assert trigger_payload["updated"] == 2
+    assert "Assignments saved" in response.text
+    assert "alice" in response.text
+    assert "bob" in response.text
+
+    updated_project = await DbProject.one(db, project.id)
+    by_task_id = {
+        f["properties"]["task_id"]: f["properties"]
+        for f in updated_project.task_areas_geojson["features"]
+    }
+    assert by_task_id[1]["assigned_to"] == "alice"
+    assert by_task_id[1]["assigned_group"] == "NE"
+    assert by_task_id[1]["building_count"] == 12
+    assert by_task_id[2]["assigned_to"] == "bob"
+    assert by_task_id[2]["assigned_group"] == "SW"
+    # Assignment is advisory: the save path must never write task status
+    assert "status" not in by_task_id[1]
+    assert "status" not in by_task_id[2]
+
+
+async def test_save_assignments_strips_control_characters(client, db, project):
+    """Control characters in free-text assignees should be stripped."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_to": "ali\u0007ce"}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    updated_project = await DbProject.one(db, project.id)
+    properties = updated_project.task_areas_geojson["features"][0]["properties"]
+    assert properties["assigned_to"] == "alice"
+
+
+async def test_save_assignments_rejects_bad_group_label(client, db, project):
+    """Group labels outside the ODK-safe charset should be rejected."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_group": "north east!"}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Group labels may only contain" in response.text
+
+    updated_project = await DbProject.one(db, project.id)
+    properties = updated_project.task_areas_geojson["features"][0]["properties"]
+    assert "assigned_group" not in properties
+
+
+async def test_save_assignments_rejects_overlong_assignee(client, db, project):
+    """Assignee values longer than 100 characters should be rejected."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_to": "a" * 101}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "100 characters or fewer" in response.text
+
+
+async def test_save_assignments_rejects_overlong_group_label(client, db, project):
+    """Group labels longer than 100 characters should be rejected."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_group": "g" * 101}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "100 characters or fewer" in response.text
+
+
+async def test_save_assignments_keeps_entity_sequences_verbatim(client, db, project):
+    """Assignees typed with HTML entity sequences must be stored verbatim.
+
+    The assignments payload is plain JSON from JSON.stringify, never
+    entity-encoded, so the save path must not HTML-unescape it.
+    """
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_to": "Bob &amp; Co"}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    updated_project = await DbProject.one(db, project.id)
+    properties = updated_project.task_areas_geojson["features"][0]["properties"]
+    assert properties["assigned_to"] == "Bob &amp; Co"
+
+
+async def test_save_assignments_rejects_unknown_task_id(client, db, project):
+    """Task ids not present in the stored task areas should be rejected."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"99": {"assigned_to": "alice"}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "Unknown task id" in response.text
+
+
+async def test_save_assignments_rejects_missing_payload(client, db, project):
+    """An empty form post should return a clear 400 error."""
+    await _set_task_areas(db, project.id, json.loads(json.dumps(_TASK_AREAS)))
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": ""},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "No assignments data provided" in response.text
+
+
+async def test_save_assignments_rejects_no_split_sentinel(client, db, project):
+    """Saving against the {} sentinel should fail with a split-first hint."""
+    await _set_task_areas(db, project.id, {})
+
+    response = await client.post(
+        f"/projects/{project.id}/assignments",
+        data={"assignments": json.dumps({"1": {"assigned_to": "alice"}})},
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "No task areas to assign" in response.text
+
+
+async def test_published_project_page_includes_assignment_panel_slot(
+    client, db, project
+):
+    """The PUBLISHED setup view should lazy-load the assignment panel."""
+    await DbProject.update(
+        db,
+        project.id,
+        DbProject(status=ProjectStatus.PUBLISHED),
+    )
+    await db.commit()
+
+    response = await client.get(
+        f"/projects/{project.id}",
+        headers={"HX-Request": "true"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'id="assignment-panel"' in response.text
+    assert f'hx-get="/projects/{project.id}/assignments-htmx"' in response.text

--- a/src/backend/tests/test_finalize_odk.py
+++ b/src/backend/tests/test_finalize_odk.py
@@ -6,6 +6,7 @@ delivery work correctly through the whole chain.
 """
 
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from io import BytesIO
 from types import SimpleNamespace
@@ -22,9 +23,12 @@ from app.projects.project_services import (
     ServiceError,
     ValidationError,
     _build_feature_dataset_payload,
+    _build_task_entities,
     derive_simple_project_metadata,
     finalize_odk_project,
+    save_task_areas,
 )
+from app.qfield.qfield_crud import _build_tasks_geojson
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -76,6 +80,15 @@ SAMPLE_DATA_EXTRACT = {
 
 DUMMY_XLSFORM = b"dummy xlsform bytes"
 _UNSET = object()
+
+
+def _task_feature(properties: Optional[dict] = None) -> dict:
+    """Build a task-area Feature with the sample polygon geometry."""
+    return {
+        "type": "Feature",
+        "geometry": SAMPLE_OUTLINE["features"][0]["geometry"],
+        "properties": properties if properties is not None else {},
+    }
 
 
 @dataclass
@@ -800,6 +813,195 @@ async def test_build_feature_dataset_payload_allows_empty_data_extract_features(
 
     assert entity_properties == []
     assert entities_list == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: stable task_id stamping and task entity building
+# ---------------------------------------------------------------------------
+
+
+async def test_save_task_areas_stamps_missing_task_ids(stub_project, db):
+    """Saving task areas should stamp sequential ids onto unstamped features."""
+    tasks_geojson = {
+        "type": "FeatureCollection",
+        "features": [_task_feature(), _task_feature(), _task_feature()],
+    }
+
+    task_count = await save_task_areas(db, stub_project.id, tasks_geojson)
+
+    assert task_count == 3
+    updated_project = await DbProject.one(db, stub_project.id)
+    stored_ids = [
+        feature["properties"]["task_id"]
+        for feature in updated_project.task_areas_geojson["features"]
+    ]
+    assert stored_ids == [1, 2, 3]
+
+
+async def test_save_task_areas_preserves_existing_ids_and_avoids_collisions(
+    stub_project, db
+):
+    """Existing task ids must stay untouched; stamped ids skip used values."""
+    tasks_geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            _task_feature(properties={"task_id": 2}),
+            _task_feature(),
+            _task_feature(properties={"task_id": 1}),
+            _task_feature(),
+        ],
+    }
+
+    await save_task_areas(db, stub_project.id, tasks_geojson)
+
+    updated_project = await DbProject.one(db, stub_project.id)
+    stored_ids = [
+        feature["properties"]["task_id"]
+        for feature in updated_project.task_areas_geojson["features"]
+    ]
+    assert stored_ids == [2, 3, 1, 4]
+
+
+async def test_save_task_areas_restamps_duplicate_and_invalid_ids(stub_project, db):
+    """Duplicate, malformed, or digit-string ids must persist as unique ints."""
+    tasks_geojson = {
+        "type": "FeatureCollection",
+        "features": [
+            _task_feature(properties={"task_id": 2}),
+            _task_feature(properties={"task_id": 2}),
+            _task_feature(properties={"task_id": "3"}),
+            _task_feature(properties={"task_id": "abc"}),
+            _task_feature(properties={"task_id": 0}),
+        ],
+    }
+
+    await save_task_areas(db, stub_project.id, tasks_geojson)
+
+    updated_project = await DbProject.one(db, stub_project.id)
+    stored_ids = [
+        feature["properties"]["task_id"]
+        for feature in updated_project.task_areas_geojson["features"]
+    ]
+    assert stored_ids == [2, 1, 3, 4, 5]
+    assert all(isinstance(task_id, int) for task_id in stored_ids)
+
+
+async def test_save_task_areas_rejects_invalid_data_format(stub_project, db):
+    """Non-dict task areas payloads should be rejected before persisting."""
+    with pytest.raises(ValidationError, match="Invalid task areas data format"):
+        await save_task_areas(db, stub_project.id, ["not", "a", "dict"])
+
+
+@pytest.mark.asyncio
+async def test_build_task_entities_uses_stored_task_ids():
+    """Entity labels and data must come from stored task_id, not position."""
+    project = FakeProject(
+        task_areas_geojson={
+            "type": "FeatureCollection",
+            "features": [
+                _task_feature(properties={"task_id": 7}),
+                _task_feature(properties={"task_id": 3}),
+            ],
+        }
+    )
+
+    async def fake_feature_geojson_to_entity_dict(feature, **kwargs):
+        return {"label": "", "data": {"geometry": "geom"}}
+
+    with patch(
+        "app.projects.project_services.central_crud.feature_geojson_to_entity_dict",
+        side_effect=fake_feature_geojson_to_entity_dict,
+    ):
+        task_entities = await _build_task_entities(project)
+
+    assert [entity["label"] for entity in task_entities] == ["Task 7", "Task 3"]
+    assert [entity["data"]["task_id"] for entity in task_entities] == ["7", "3"]
+
+
+@pytest.mark.asyncio
+async def test_build_task_entities_stamps_legacy_rows_in_memory():
+    """Features saved before id stamping get in-memory ids matching position."""
+    project = FakeProject(
+        task_areas_geojson={
+            "type": "FeatureCollection",
+            "features": [_task_feature(), _task_feature()],
+        }
+    )
+
+    async def fake_feature_geojson_to_entity_dict(feature, **kwargs):
+        return {"label": "", "data": {"geometry": "geom"}}
+
+    with patch(
+        "app.projects.project_services.central_crud.feature_geojson_to_entity_dict",
+        side_effect=fake_feature_geojson_to_entity_dict,
+    ):
+        task_entities = await _build_task_entities(project)
+
+    assert [entity["label"] for entity in task_entities] == ["Task 1", "Task 2"]
+    assert [entity["data"]["task_id"] for entity in task_entities] == ["1", "2"]
+
+
+@pytest.mark.asyncio
+async def test_build_task_entities_agrees_with_qfield_builder_on_mixed_ids():
+    """Both export builders must derive identical ids from the same fixture."""
+    featcol = {
+        "type": "FeatureCollection",
+        "features": [
+            _task_feature(),
+            _task_feature(properties={"task_id": 1}),
+            _task_feature(properties={"task_id": 4}),
+            _task_feature(),
+        ],
+    }
+
+    qfield_project = SimpleNamespace(task_areas_geojson=deepcopy(featcol), outline=None)
+    qfield_ids = [
+        feature["properties"]["task_id"]
+        for feature in _build_tasks_geojson(qfield_project)["features"]
+    ]
+
+    odk_project = FakeProject(task_areas_geojson=deepcopy(featcol))
+
+    async def fake_feature_geojson_to_entity_dict(feature, **kwargs):
+        return {"label": "", "data": {"geometry": "geom"}}
+
+    with patch(
+        "app.projects.project_services.central_crud.feature_geojson_to_entity_dict",
+        side_effect=fake_feature_geojson_to_entity_dict,
+    ):
+        task_entities = await _build_task_entities(odk_project)
+    odk_ids = [int(entity["data"]["task_id"]) for entity in task_entities]
+
+    assert qfield_ids == [2, 1, 4, 3]
+    assert odk_ids == qfield_ids
+
+
+@pytest.mark.asyncio
+async def test_build_task_entities_outline_fallback_stays_task_one():
+    """The single-task outline fallback must keep its canonical task id 1."""
+    project = FakeProject(task_areas_geojson=None)
+
+    async def fake_feature_geojson_to_entity_dict(feature, **kwargs):
+        return {"label": "", "data": {"geometry": "geom"}}
+
+    with patch(
+        "app.projects.project_services.central_crud.feature_geojson_to_entity_dict",
+        side_effect=fake_feature_geojson_to_entity_dict,
+    ):
+        task_entities = await _build_task_entities(project)
+
+    assert len(task_entities) == 1
+    assert task_entities[0]["label"] == "Task 1"
+    assert task_entities[0]["data"]["task_id"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_build_task_entities_requires_outline_when_no_task_areas():
+    """Missing both task areas and outline should fail with a clear error."""
+    project = FakeProject(task_areas_geojson=None, outline_geojson=None)
+
+    with pytest.raises(ValidationError, match="Project outline is missing"):
+        await _build_task_entities(project)
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/test_qfield_routes.py
+++ b/src/backend/tests/test_qfield_routes.py
@@ -27,6 +27,7 @@ import pytest
 from app.qfield import qfield_crud
 from app.qfield.qfield_crud import (
     _build_qfc_service_account_email,
+    _build_tasks_geojson,
     _create_qfc_user,
     _is_org_owned_project,
     _resolve_backend_qfc_url,
@@ -92,6 +93,75 @@ def test_clean_tags_for_qgis_stringifies_nested_properties():
         "building": "yes",
         "levels": "2",
     }
+
+
+def test_build_tasks_geojson_keeps_stored_ids_and_stamps_legacy_rows():
+    """Stored task ids win; legacy unstamped features get non-colliding ids."""
+    project = SimpleNamespace(
+        task_areas_geojson={
+            "type": "FeatureCollection",
+            "features": [
+                {"type": "Feature", "geometry": None, "properties": {}},
+                {"type": "Feature", "geometry": None, "properties": {"task_id": 1}},
+                {"type": "Feature", "geometry": None, "properties": {"task_id": 4}},
+                {"type": "Feature", "geometry": None, "properties": {}},
+            ],
+        },
+        outline=None,
+    )
+
+    tasks_geojson = _build_tasks_geojson(project)
+
+    stored_ids = [
+        feature["properties"]["task_id"] for feature in tasks_geojson["features"]
+    ]
+    assert stored_ids == [2, 1, 4, 3]
+
+
+def test_build_tasks_geojson_restamps_duplicate_and_invalid_ids():
+    """Duplicate or malformed stored ids must come out as unique integers."""
+    project = SimpleNamespace(
+        task_areas_geojson={
+            "type": "FeatureCollection",
+            "features": [
+                {"type": "Feature", "geometry": None, "properties": {"task_id": 1}},
+                {"type": "Feature", "geometry": None, "properties": {"task_id": 1}},
+                {"type": "Feature", "geometry": None, "properties": {"task_id": "2"}},
+                {"type": "Feature", "geometry": None, "properties": {"task_id": "abc"}},
+            ],
+        },
+        outline=None,
+    )
+
+    tasks_geojson = _build_tasks_geojson(project)
+
+    stored_ids = [
+        feature["properties"]["task_id"] for feature in tasks_geojson["features"]
+    ]
+    assert stored_ids == [1, 3, 2, 4]
+    assert all(isinstance(task_id, int) for task_id in stored_ids)
+
+
+def test_build_tasks_geojson_falls_back_to_single_outline_task():
+    """No stored task areas should yield a single outline task with id 1."""
+    project = SimpleNamespace(
+        task_areas_geojson={},
+        outline={"type": "Point", "coordinates": [85.3, 27.7]},
+    )
+
+    tasks_geojson = _build_tasks_geojson(project)
+
+    assert len(tasks_geojson["features"]) == 1
+    assert tasks_geojson["features"][0]["properties"]["task_id"] == 1
+
+
+def test_build_tasks_geojson_returns_empty_collection_without_outline():
+    """No task areas and no outline should produce an empty FeatureCollection."""
+    project = SimpleNamespace(task_areas_geojson=None, outline=None)
+
+    tasks_geojson = _build_tasks_geojson(project)
+
+    assert tasks_geojson == {"type": "FeatureCollection", "features": []}
 
 
 def test_resolve_qfield_project_url_prefers_absolute_api_url():


### PR DESCRIPTION
## What

A first, **"assign in advance"** task assignment UI for project managers, addressing #3095. Managers get a panel on the project details page that shows task areas on a map, lets them select tasks and apply an assignee + group label (with one-click quadrant auto-grouping for the NE/SW/SE/NW bulk case), and persists assignments as feature properties on the existing `task_areas_geojson`.

This is opened as a **draft for discussion** — it implements the durable "edit in the browser, confirm to save" half of the issue. The field-device sync (QFieldCloud geopackage / ODK entity push) and the CoMaps `.kmz` export (#3064) are deliberately deferred to follow-up PRs (see _Deferred_ below). I'd value a steer on the open questions before going further.

## How it fits the existing architecture

No SPA, no build step, no new dependencies, no schema change — entirely server-rendered LiteStar + HTMX + Jinja2 with a flat static JS file, per `AGENTS.md` and the existing decisions.

Two commits:

1. **`fix(backend): stabilize task_id across save and export paths`** — a small prerequisite refactor. Task ids were assigned positionally and divergently in the QField (`_build_tasks_geojson`) and ODK (`_build_task_entities`) export paths, so the two ecosystems could disagree on task identity. This stamps a persistent, collision-safe integer `task_id` into `task_areas_geojson` features on save and makes both export builders read the stored id. This is the keystone the assignment feature keys on, and is independently useful — happy to split it into its own PR if you'd prefer.

2. **`feat(htmx): task assignment map panel for project managers`** — the panel itself:
   - New `app/htmx/assignment/` module with three `project_manager`-gated routes: a lazy-loaded panel fragment, a JSON `assignments/geojson` endpoint (tasks merged with `assigned_to` / `assigned_group`), and a `POST` save.
   - `save_task_assignments` service alongside `save_task_areas`: validates the group label (`^[a-zA-Z0-9_-]*$`), caps/sanitises the assignee, rejects unknown task ids, merges into feature properties under a `FOR UPDATE` row lock, and **never writes `status`** — task state stays owned by the field apps.
   - `task_assignment.js` (flat file, reuses the global Leaflet): click / shift-click selection shared between map and table, quadrant auto-grouping, draft edits staged in `sessionStorage` (matching the existing `ftm-draft-aoi-outline` precedent) and replayed over fresh server data, all user values rendered via `textContent` only.
   - Confirm warnings on the data-extract / re-split steps when stored assignments would be discarded.

## Screenshots

**Assignment panel** — task areas on a map, quadrant-coloured by group, with the summary table below:

![Assignment panel](https://github.com/kartikey54/field-tm/releases/download/fieldtm-3095-assets/01-assignment-panel.png)

**Selecting tasks** — click / shift-click on the map and table, then apply an assignee + group to the selection:

![Selecting tasks](https://github.com/kartikey54/field-tm/releases/download/fieldtm-3095-assets/02-selection.png)

**After saving** — assignments persisted to feature properties and reflected in the table:

![After saving](https://github.com/kartikey54/field-tm/releases/download/fieldtm-3095-assets/03-saved-table.png)

## Tests

34 new tests (`tests/htmx/test_assignment_routes.py`, plus task-id stability coverage in `test_finalize_odk.py` / `test_qfield_routes.py`): route registration and auth, geojson shape and defaults, the save happy path (incl. `HX-Trigger` payload and that `status` is never written), XSS escaping, validation rejects (bad group label, overlong assignee, unknown task id, missing payload), the empty/`{}` no-split sentinel, and cross-builder task-id agreement. Local backend suite: **305 passed, 0 failed** (the two ODK-Central / QGIS-container suites were not run locally).

## Deliberately deferred (happy to sequence as follow-ups)

- **ODK entity sync** — push `assigned_to` / `assigned_group` to the `tasks` dataset entities (most machinery already exists in `central_crud`).
- **QFieldCloud sync** — pull `tasks.gpkg`, merge assignment fields by `task_id`, push back; plus stopping `_add_plugin_task_fields` from clobbering assignments on regeneration.
- **CoMaps / Organic Maps `.kmz` export** (#3064).
- **Field status read-back** (showing live task progress on the manager's map) — depends on the sync work above.

## Open questions

1. **Storage shape:** assignments as `task_areas_geojson` feature properties (this PR) vs a relational `task_assignments` table (audit trail, row-level locking). I went properties-first to keep this PR schema-free; would you want the table from the start?
2. **Permissions:** nothing in the codebase appears to write `user_roles`, so `project_manager` only resolves for global admins in deployments today. Should project creators get a project-admin role at creation?
3. **Assignee identity:** free-text `assigned_to` (covers account-less mappers / shared QFC accounts) with opportunistic QFC-collaborator suggestions — acceptable, or should assignment drive per-mapper QFC user provisioning?
4. **Groups:** is the free-text `assigned_group` label the right model for the quadrant use case, or did you envision groups of *users*?
5. **Single-task projects** (`task_areas_geojson == {}`): this PR shows a "split first" callout rather than materialising a synthetic single task — OK?

---

Refs #3095. Related #3064.
