### PR TITLE
fix(splitter): handle polygons with connected rings

### DIFF
--- a/src/backend/packages/area-splitter/area_splitter/db.py
+++ b/src/backend/packages/area-splitter/area_splitter/db.py
@@ -194,7 +194,7 @@ def aoi_to_postgis(conn: psycopg.Connection, geom: dict) -> None:
 
     sql_insert = """
         INSERT INTO project_aoi (geom)
-        VALUES (ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326))
+        VALUES (ST_MakeValid(ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326)))
         RETURNING id, geom;
     """
 
@@ -235,7 +235,7 @@ def insert_geoms_batch(
 
     query = (
         f"INSERT INTO {table_name} (geom, osm_id, tags) "
-        "VALUES (ST_SetSRID(ST_GeomFromGeoJSON(%(geom)s), 4326), %(osm_id)s, %(tags)s)"
+        "VALUES (ST_MakeValid(ST_SetSRID(ST_GeomFromGeoJSON(%(geom)s), 4326)), %(osm_id)s, %(tags)s)"
     )
     prepared = [{**row, "tags": Json(row.get("tags"))} for row in rows]
     cur.executemany(query, prepared)

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from time import sleep
 
+import psycopg
 import pytest
 from psycopg.types.json import Json
 
@@ -40,6 +41,10 @@ from area_splitter.splitter import (
 
 log = logging.getLogger(__name__)
 TESTDATA_DIR = str(Path(__file__).parent / "testdata")
+# splitBySQL commits and closes whatever connection it is given, so scenario
+# tests below open a fresh connection per call instead of sharing the
+# session-scoped `db` fixture (which later tests still rely on).
+DB_URL = "postgresql://fieldtm:fieldtm@fieldtm-db:5432/fieldtm"
 
 
 class _RecordingCursor:
@@ -445,6 +450,283 @@ def test_split_by_sql_ftm_multi_geom(extract_json):
 
     polygon = polygons[0].get("geometry")
     assert isinstance(polygon, dict) and polygon.get("type") == "Polygon"
+
+
+def _square_ring(lon, lat, size_deg):
+    """Build a closed square ring (exterior or hole) as a coordinate list."""
+    return [
+        [lon, lat],
+        [lon + size_deg, lat],
+        [lon + size_deg, lat + size_deg],
+        [lon, lat + size_deg],
+        [lon, lat],
+    ]
+
+
+def _building_feature(geometry, osm_id):
+    """Wrap a geometry as a minimal tagged building Feature."""
+    return {
+        "type": "Feature",
+        "geometry": geometry,
+        "properties": {"building": "yes", "osm_id": osm_id},
+    }
+
+
+def _aoi_featcol(lon, lat, width_deg, height_deg):
+    """Build a single-feature AOI FeatureCollection for a rectangle."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [lon, lat],
+                            [lon + width_deg, lat],
+                            [lon + width_deg, lat + height_deg],
+                            [lon, lat + height_deg],
+                            [lon, lat],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+
+
+def _extract_featcol(features):
+    """Wrap building features as an OSM extract FeatureCollection."""
+    return {"type": "FeatureCollection", "features": features}
+
+
+def _assert_tasks_valid_and_bounded_by_aoi(aoi_geometry, features, overshoot_tolerance=0.02):
+    """Assert every task polygon is valid, non-overlapping, and stays within the AOI.
+
+    The straight skeleton algorithm intentionally only builds task polygons
+    around building clusters - regions of the AOI far from any building are
+    dropped, so task coverage is *not* expected to reconstruct the full AOI
+    (confirmed empirically: even the dense real-world Kathmandu fixture only
+    covers ~93% of its AOI). What must always hold is that every task is a
+    valid geometry, tasks don't significantly overlap each other, and their
+    union never spills meaningfully outside the AOI.
+
+    Opens its own connection rather than reusing one already handed to
+    split_by_sql/splitBySQL, since that call commits and closes it.
+    """
+    assert features, "Splitting must return at least one task polygon"
+    task_geoms = json.dumps([feature["geometry"] for feature in features])
+
+    with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH aoi AS (
+                SELECT ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326) AS geom
+            ),
+            tasks AS (
+                SELECT ST_SetSRID(ST_GeomFromGeoJSON(value), 4326) AS geom
+                FROM jsonb_array_elements_text(%s::jsonb) AS value
+            )
+            SELECT
+                bool_and(ST_IsValid(tasks.geom)),
+                ST_Area((SELECT geom FROM aoi)::geography),
+                ST_Area(ST_Union(tasks.geom)::geography),
+                SUM(ST_Area(tasks.geom::geography)),
+                ST_Area(ST_Difference(
+                    ST_Union(tasks.geom), (SELECT geom FROM aoi)
+                )::geography)
+            FROM tasks;
+            """,
+            (json.dumps(aoi_geometry), task_geoms),
+        )
+        all_valid, aoi_area, union_area, summed_area, outside_area = cur.fetchone()
+
+    assert all_valid, "Every returned task polygon must be a valid geometry"
+    assert union_area > 0, "Tasks must cover a non-zero area"
+    assert summed_area == pytest.approx(union_area, rel=0.02), (
+        "Task polygons should not significantly overlap each other"
+    )
+    assert outside_area <= aoi_area * overshoot_tolerance, (
+        f"Tasks should stay within the AOI, but {outside_area} sq.m falls outside "
+        f"of the {aoi_area} sq.m AOI"
+    )
+
+
+def test_split_by_sql_skeleton_handles_connected_ring_building():
+    """Regression test for hotosm#3081.
+
+    ST_GeomFromGeoJSON accepts a polygon whose interior ring touches the
+    exterior ring at a single vertex ("connected rings"). Before the
+    ST_MakeValid fix, running the straight skeleton algorithm on an extract
+    containing such a building crashed with:
+    "Intersection does not support polygon with connected rings".
+    """
+    lon, lat = 85.3200, 27.7000
+    aoi = _aoi_featcol(lon, lat, 0.0006, 0.0004)
+
+    connected_ring_building = {
+        "type": "Polygon",
+        "coordinates": [
+            _square_ring(lon + 0.00005, lat + 0.00005, 0.00012),
+            # Hole's first vertex is exactly the exterior ring's first
+            # vertex, so the rings touch at a single point.
+            _square_ring(lon + 0.00005, lat + 0.00005, 0.00006),
+        ],
+    }
+    normal_building = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.0003, lat + 0.0002, 0.0001)],
+    }
+    extract = _extract_featcol(
+        [
+            _building_feature(connected_ring_building, 1),
+            _building_feature(normal_building, 2),
+        ]
+    )
+
+    features = split_by_sql(aoi, DB_URL, num_buildings=50, osm_extract=extract).get(
+        "features", []
+    )
+
+    _assert_tasks_valid_and_bounded_by_aoi(aoi["features"][0]["geometry"], features)
+
+
+def test_split_by_sql_skeleton_handles_building_with_hole():
+    """A building with a real (non-touching) interior hole should still work.
+
+    This guards against the ST_MakeValid fix changing behaviour for
+    already-valid donut-shaped buildings.
+    """
+    lon, lat = 85.3300, 27.7000
+    aoi = _aoi_featcol(lon, lat, 0.0006, 0.0004)
+
+    donut_building = {
+        "type": "Polygon",
+        "coordinates": [
+            _square_ring(lon + 0.00005, lat + 0.00005, 0.0002),
+            _square_ring(lon + 0.0001, lat + 0.0001, 0.00005),
+        ],
+    }
+    extract = _extract_featcol([_building_feature(donut_building, 1)])
+
+    features = split_by_sql(aoi, DB_URL, num_buildings=50, osm_extract=extract).get(
+        "features", []
+    )
+
+    _assert_tasks_valid_and_bounded_by_aoi(aoi["features"][0]["geometry"], features)
+
+
+def test_split_by_sql_skeleton_single_building():
+    """A single building in the extract should not break clustering."""
+    lon, lat = 85.3400, 27.7000
+    aoi = _aoi_featcol(lon, lat, 0.0004, 0.0004)
+
+    building = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.00015, lat + 0.00015, 0.0001)],
+    }
+    extract = _extract_featcol([_building_feature(building, 1)])
+
+    features = split_by_sql(aoi, DB_URL, num_buildings=50, osm_extract=extract).get(
+        "features", []
+    )
+
+    _assert_tasks_valid_and_bounded_by_aoi(aoi["features"][0]["geometry"], features)
+
+
+def test_split_by_sql_skeleton_sparse_buildings():
+    """Buildings scattered far apart within a large, mostly-empty AOI."""
+    lon, lat = 85.3500, 27.7000
+    aoi = _aoi_featcol(lon, lat, 0.004, 0.004)
+
+    near_corner_building = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.0001, lat + 0.0001, 0.0001)],
+    }
+    far_corner_building = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.0037, lat + 0.0037, 0.0001)],
+    }
+    extract = _extract_featcol(
+        [
+            _building_feature(near_corner_building, 1),
+            _building_feature(far_corner_building, 2),
+        ]
+    )
+
+    features = split_by_sql(aoi, DB_URL, num_buildings=50, osm_extract=extract).get(
+        "features", []
+    )
+
+    _assert_tasks_valid_and_bounded_by_aoi(aoi["features"][0]["geometry"], features)
+
+
+def test_split_by_sql_skeleton_concave_aoi():
+    """An L-shaped (concave) AOI with buildings in each arm."""
+    lon, lat = 85.3600, 27.7000
+
+    # L-shape: a 0.0008 x 0.0008 square with the top-right 0.0004 x 0.0004
+    # quadrant removed.
+    l_shape_aoi = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [lon, lat],
+                            [lon + 0.0008, lat],
+                            [lon + 0.0008, lat + 0.0004],
+                            [lon + 0.0004, lat + 0.0004],
+                            [lon + 0.0004, lat + 0.0008],
+                            [lon, lat + 0.0008],
+                            [lon, lat],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+
+    building_in_horizontal_arm = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.0005, lat + 0.0001, 0.0001)],
+    }
+    building_in_vertical_arm = {
+        "type": "Polygon",
+        "coordinates": [_square_ring(lon + 0.0001, lat + 0.0005, 0.0001)],
+    }
+    extract = _extract_featcol(
+        [
+            _building_feature(building_in_horizontal_arm, 1),
+            _building_feature(building_in_vertical_arm, 2),
+        ]
+    )
+
+    features = split_by_sql(
+        l_shape_aoi, DB_URL, num_buildings=50, osm_extract=extract
+    ).get("features", [])
+
+    _assert_tasks_valid_and_bounded_by_aoi(l_shape_aoi["features"][0]["geometry"], features)
+
+
+def test_split_by_sql_skeleton_task_polygons_cover_aoi(aoi_json, extract_json):
+    """Real-world Kathmandu extract: tasks should jointly reconstruct the AOI.
+
+    This is an invariant check (validity + area coverage) rather than an
+    exact feature count, so it stays meaningful even if the clustering
+    output shape changes.
+    """
+    features = split_by_sql(
+        aoi_json, DB_URL, num_buildings=10, osm_extract=extract_json
+    ).get("features", [])
+
+    _assert_tasks_valid_and_bounded_by_aoi(aoi_json["features"][0]["geometry"], features)
 
 
 def test_cli_help(capsys):

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -502,7 +502,9 @@ def _extract_featcol(features):
     return {"type": "FeatureCollection", "features": features}
 
 
-def _assert_tasks_valid_and_bounded_by_aoi(aoi_geometry, features, overshoot_tolerance=0.02):
+def _assert_tasks_valid_and_bounded_by_aoi(
+    aoi_geometry, features, overshoot_tolerance=0.02
+):
     """Assert every task polygon is valid, non-overlapping, and stays within the AOI.
 
     The straight skeleton algorithm intentionally only builds task polygons
@@ -712,7 +714,9 @@ def test_split_by_sql_skeleton_concave_aoi():
         l_shape_aoi, DB_URL, num_buildings=50, osm_extract=extract
     ).get("features", [])
 
-    _assert_tasks_valid_and_bounded_by_aoi(l_shape_aoi["features"][0]["geometry"], features)
+    _assert_tasks_valid_and_bounded_by_aoi(
+        l_shape_aoi["features"][0]["geometry"], features
+    )
 
 
 def test_split_by_sql_skeleton_task_polygons_cover_aoi(aoi_json, extract_json):
@@ -726,7 +730,9 @@ def test_split_by_sql_skeleton_task_polygons_cover_aoi(aoi_json, extract_json):
         aoi_json, DB_URL, num_buildings=10, osm_extract=extract_json
     ).get("features", [])
 
-    _assert_tasks_valid_and_bounded_by_aoi(aoi_json["features"][0]["geometry"], features)
+    _assert_tasks_valid_and_bounded_by_aoi(
+        aoi_json["features"][0]["geometry"], features
+    )
 
 
 def test_cli_help(capsys):

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -123,6 +123,7 @@ def test_insert_geoms_batch_uses_executemany_and_json_tags():
     assert len(cur.calls) == 1
     query, params = cur.calls[0]
     assert "INSERT INTO ways_poly" in query
+    assert "ST_MakeValid" in query
     assert len(params) == 2
     assert isinstance(params[0]["tags"], Json)
     assert params[0]["osm_id"] == 1


### PR DESCRIPTION
Closes #3081

## Problem
`ST_GeomFromGeoJSON` accepts polygons where an interior ring touches the exterior ring. These pass validation but cause PostGIS/GEOS to throw `Intersection does not support polygon with connected rings` when the straight skeleton SQL runs `ST_Intersection` on them.

## Fix
Wrap geometries in `ST_MakeValid()` at insert time in `db.py`:
- `insert_geoms_batch()` — covers OSM building polygons and linear features
- `aoi_to_postgis()` — covers the project AOI itself

`ST_MakeValid` converts connected-ring polygons into valid multi-polygons, which downstream SQL already handles via `ST_Dump()`.

## Test
Added a regression assertion to the existing `test_insert_geoms_batch_uses_executemany_and_json_tags` test confirming `ST_MakeValid` is present in the generated SQL.

(Replaces the incorrectly-linked #3103, which is an unrelated docs PR.)