### PR TITLE
feat(splitter): add split-by-roads task splitting algorithm

### DIFF
--- a/docs/manuals/task-splitting.md
+++ b/docs/manuals/task-splitting.md
@@ -65,15 +65,31 @@ Needs: AOI polygon, OSM extract, target number of tasks.
 
 [More details about how this algorithm works](https://github.com/hotosm/field-tm/blob/dev/src/backend/packages/area-splitter/docs/algorithms/straight-skeleton.md).
 
+### Split by Roads
+
+Task boundaries are exactly the polygons enclosed by roads, rivers,
+railways, aeroways, and non-traversable barriers — no building
+clustering. Each task is bounded by the streets around it.
+
+Best for street-level data collection (e.g. imagery capture) where
+mappers walk or cycle roads rather than visiting individual buildings.
+Task size isn't controllable — it follows however dense the street
+network is.
+
+Needs: AOI polygon, OSM extract with roads.
+
+[More details about how this algorithm works](https://github.com/hotosm/field-tm/blob/dev/src/backend/packages/area-splitter/docs/algorithms/roads.md).
+
 ## Which one to pick
 
-| Situation                          | Use                      |
-| ---------------------------------- | ------------------------ |
-| Very small AOI, one mapper         | No Splitting             |
-| No OSM data, or a sparse area      | Split by Square          |
-| You know how many mappers you have | Specific Number of Tasks |
-| Standard case, building-dense area | Average Buildings v2     |
-| Reproducing an older project       | Average Buildings v1     |
+| Situation                               | Use                      |
+| ---------------------------------------- | ------------------------ |
+| Very small AOI, one mapper              | No Splitting             |
+| No OSM data, or a sparse area           | Split by Square          |
+| You know how many mappers you have      | Specific Number of Tasks |
+| Standard case, building-dense area      | Average Buildings v2     |
+| Reproducing an older project            | Average Buildings v1     |
+| Street-level mapping (walk/cycle roads) | Split by Roads           |
 
 ## What the feature-based options do
 

--- a/docs/manuals/task-splitting.md
+++ b/docs/manuals/task-splitting.md
@@ -83,7 +83,7 @@ Needs: AOI polygon, OSM extract with roads.
 ## Which one to pick
 
 | Situation                               | Use                      |
-| ---------------------------------------- | ------------------------ |
+| --------------------------------------- | ------------------------ |
 | Very small AOI, one mapper              | No Splitting             |
 | No OSM data, or a sparse area           | Split by Square          |
 | You know how many mappers you have      | Specific Number of Tasks |

--- a/src/backend/app/projects/project_services.py
+++ b/src/backend/app/projects/project_services.py
@@ -951,7 +951,7 @@ def _validate_split_extract(parsed_extract) -> None:
         )
 
 
-async def _split_with_building_algorithm(  # noqa: PLR0913
+async def _split_with_sql_algorithm(  # noqa: PLR0913
     aoi_featcol: dict,
     parsed_extract: dict,
     algorithm_enum: SplittingAlgorithm,
@@ -962,7 +962,7 @@ async def _split_with_building_algorithm(  # noqa: PLR0913
     include_aeroways: bool,
     statement_timeout_ms: Optional[int] = None,
 ) -> dict:
-    """Run one of the SQL-backed building-based split algorithms."""
+    """Run one of the SQL-backed split algorithms (building-based or roads-only)."""
     _validate_split_extract(parsed_extract)
     algorithm_params = {
         **algorithm_params,
@@ -1078,7 +1078,7 @@ async def split_aoi(
         SplittingAlgorithm.AVG_BUILDING_VORONOI,
         SplittingAlgorithm.AVG_BUILDING_SKELETON,
     ):
-        features = await _split_with_building_algorithm(
+        features = await _split_with_sql_algorithm(
             aoi_featcol,
             parsed_extract,
             algorithm_enum,
@@ -1096,11 +1096,22 @@ async def split_aoi(
             options.dimension_meters,
         )
     elif algorithm_enum == SplittingAlgorithm.TOTAL_TASKS:
-        features = await _split_with_building_algorithm(
+        features = await _split_with_sql_algorithm(
             aoi_featcol,
             parsed_extract,
             algorithm_enum,
             {"num_enumerators": options.no_of_tasks},
+            options.include_roads,
+            options.include_rivers,
+            options.include_railways,
+            options.include_aeroways,
+        )
+    elif algorithm_enum == SplittingAlgorithm.SPLIT_BY_ROADS:
+        features = await _split_with_sql_algorithm(
+            aoi_featcol,
+            parsed_extract,
+            algorithm_enum,
+            {},
             options.include_roads,
             options.include_rivers,
             options.include_railways,

--- a/src/backend/app/static/js/project_setup_split.js
+++ b/src/backend/app/static/js/project_setup_split.js
@@ -86,7 +86,7 @@ export function initProjectSetupSplit({ i18nStrings }) {
     const splitBtnText = document.getElementById("split-btn-text");
 
     if (paramContainer) {
-      paramContainer.style.display = algorithm && algorithm !== "NO_SPLITTING" ? "block" : "none";
+      paramContainer.style.display = algorithm in algorithmActiveParam ? "block" : "none";
     }
 
     if (splitBtnText) {

--- a/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
@@ -123,6 +123,7 @@ if has_task_areas %}
           </option>
           <option value="DIVIDE_BY_SQUARE">{{ _("By a regular grid") }}</option>
           <option value="TOTAL_TASKS">{{ _("Into a fixed number of tasks") }}</option>
+          <option value="SPLIT_BY_ROADS">{{ _("Along roads only (for street-level mapping)") }}</option>
         </select>
         {% if skeleton_disabled %}
         <p class="ftm-step-field__hint" style="margin-top: 6px">

--- a/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps/step4_split.html
@@ -123,7 +123,9 @@ if has_task_areas %}
           </option>
           <option value="DIVIDE_BY_SQUARE">{{ _("By a regular grid") }}</option>
           <option value="TOTAL_TASKS">{{ _("Into a fixed number of tasks") }}</option>
-          <option value="SPLIT_BY_ROADS">{{ _("Along roads only (for street-level mapping)") }}</option>
+          <option value="SPLIT_BY_ROADS">
+            {{ _("Along roads only (for street-level mapping)") }}
+          </option>
         </select>
         {% if skeleton_disabled %}
         <p class="ftm-step-field__hint" style="margin-top: 6px">

--- a/src/backend/packages/area-splitter/README.md
+++ b/src/backend/packages/area-splitter/README.md
@@ -52,7 +52,7 @@ pip install area-splitter
 
 ## Splitting Options
 
-Five algorithms are available via the `SplittingAlgorithm` enum:
+Six algorithms are available via the `SplittingAlgorithm` enum:
 
 - `NO_SPLITTING`: return the AOI as one task.
 - `DIVIDE_BY_SQUARE`: grid of squares clipped to the AOI (default
@@ -63,6 +63,9 @@ Five algorithms are available via the `SplittingAlgorithm` enum:
   `CG_StraightSkeleton` for cleaner task edges. Needs SFCGAL.
 - `TOTAL_TASKS`: same SQL as v2, but sized by target task count
   instead of buildings per task.
+- `SPLIT_BY_ROADS`: task boundaries are exactly the polygons enclosed
+  by roads/rivers/etc, no building clustering. See
+  [docs/algorithms/roads.md](docs/algorithms/roads.md).
 
 The three SQL-based algorithms share a six-step pipeline. See
 [docs/pipeline.md](docs/pipeline.md) for the full walkthrough, and

--- a/src/backend/packages/area-splitter/area_splitter/__init__.py
+++ b/src/backend/packages/area-splitter/area_splitter/__init__.py
@@ -14,10 +14,11 @@ class SplittingAlgorithm(StrEnum):
     AVG_BUILDING_VORONOI = "AVG_BUILDING_VORONOI"
     AVG_BUILDING_SKELETON = "AVG_BUILDING_SKELETON"
     TOTAL_TASKS = "TOTAL_TASKS"
+    SPLIT_BY_ROADS = "SPLIT_BY_ROADS"
 
     @property
     def sql_path(self) -> Path | None:
-        """Get SQL file path for building-based algorithms."""
+        """Get the algorithm-specific (step 4) SQL file for building-based algorithms."""
         if self in (
             SplittingAlgorithm.AVG_BUILDING_VORONOI,
             SplittingAlgorithm.AVG_BUILDING_SKELETON,
@@ -34,6 +35,25 @@ class SplittingAlgorithm(StrEnum):
         return None
 
     @property
+    def sql_files(self) -> list[Path] | None:
+        """Ordered SQL files to run for SQL-based splitting, or None if not SQL-based."""
+        if self.sql_path:
+            return [
+                algorithms_path / "common/1-linear-features.sql",
+                algorithms_path / "common/2-group-buildings.sql",
+                algorithms_path / "common/3-cluster-buildings.sql",
+                self.sql_path,
+                algorithms_path / "common/5-alignment.sql",
+                algorithms_path / "common/6-extract.sql",
+            ]
+        if self is SplittingAlgorithm.SPLIT_BY_ROADS:
+            return [
+                algorithms_path / "common/1-linear-features.sql",
+                algorithms_path / "split_by_roads.sql",
+            ]
+        return None
+
+    @property
     def label(self) -> str:
         """Human-readable name."""
         return {
@@ -44,6 +64,7 @@ class SplittingAlgorithm(StrEnum):
                 "Average Buildings v2 (Straight Skeleton)"
             ),
             SplittingAlgorithm.TOTAL_TASKS: "Split by Specific Number of Tasks",
+            SplittingAlgorithm.SPLIT_BY_ROADS: "Split by Roads",
         }[self]
 
     @property
@@ -55,4 +76,5 @@ class SplittingAlgorithm(StrEnum):
             SplittingAlgorithm.AVG_BUILDING_VORONOI: ["num_buildings"],
             SplittingAlgorithm.AVG_BUILDING_SKELETON: ["num_buildings"],
             SplittingAlgorithm.TOTAL_TASKS: ["num_enumerators"],
+            SplittingAlgorithm.SPLIT_BY_ROADS: [],
         }[self]

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/split_by_roads.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/split_by_roads.sql
@@ -1,0 +1,25 @@
+-- Generate GeoJSON output directly from the road-bounded polygons
+-- produced by common/1-linear-features.sql (polygonsnocount), with no
+-- building-clustering/alignment steps in between.
+SELECT
+    JSONB_BUILD_OBJECT(
+        'type', 'FeatureCollection',
+        'features', JSONB_AGG(feature)
+    )
+FROM (
+    SELECT
+        JSONB_BUILD_OBJECT(
+            'type', 'Feature',
+            'geometry', ST_ASGEOJSON(t.geom)::jsonb,
+            'properties', JSONB_BUILD_OBJECT(
+                'building_count', (
+                    SELECT COUNT(b.id)
+                    FROM ways_poly AS b
+                    WHERE
+                        b.tags ->> 'building' IS NOT NULL
+                        AND ST_CONTAINS(t.geom, ST_CENTROID(b.geom))
+                )
+            )
+        ) AS feature
+    FROM polygonsnocount AS t
+) AS features;

--- a/src/backend/packages/area-splitter/area_splitter/splitter.py
+++ b/src/backend/packages/area-splitter/area_splitter/splitter.py
@@ -155,10 +155,10 @@ def _require_split_output(
 
 
 def _validate_algorithm_selection(algorithm: SplittingAlgorithm) -> None:
-    """Ensure the selected splitting algorithm has a SQL path."""
-    if algorithm.sql_path:
+    """Ensure the selected splitting algorithm has SQL files defined."""
+    if algorithm.sql_files:
         return
-    err = f"SplittingAlgorithm {algorithm} must have an sql_path defined."
+    err = f"SplittingAlgorithm {algorithm} must have sql_files defined."
     log.error(err)
     raise ValueError(err)
 
@@ -183,7 +183,7 @@ def _resolve_algorithm_params(
             params["num_buildings"] = num_buildings
         elif num_enumerators:
             params["num_enumerators"] = num_enumerators
-        else:
+        elif algorithm.required_params:
             err = (
                 f"Algorithm {algorithm.value} requires the following parameters: "
                 f"{', '.join(algorithm.required_params)}. "
@@ -604,8 +604,8 @@ class AreaSplitter:
             )
             log.error(msg)
             raise ValueError(msg)
-        if not algorithm.sql_path:
-            msg = f"Algorithm {algorithm} does not have an SQL file path"
+        if not algorithm.sql_files:
+            msg = f"Algorithm {algorithm} does not have SQL files defined"
             log.error(msg)
             raise ValueError(msg)
         missing_params = [
@@ -666,14 +666,7 @@ class AreaSplitter:
         params: dict,
     ) -> list:
         """Execute the ordered SQL algorithm files and return feature rows."""
-        sql_files = [
-            "common/1-linear-features.sql",
-            "common/2-group-buildings.sql",
-            "common/3-cluster-buildings.sql",
-            algorithm.sql_path,
-            "common/5-alignment.sql",
-            "common/6-extract.sql",
-        ]
+        sql_files = algorithm.sql_files
         log.info(f"Running task splitting algorithm parts in order: {sql_files}")
         for sql_file in sql_files:
             sql_file_path = (

--- a/src/backend/packages/area-splitter/docs/algorithms/roads.md
+++ b/src/backend/packages/area-splitter/docs/algorithms/roads.md
@@ -1,0 +1,42 @@
+# Split by Roads
+
+`SPLIT_BY_ROADS`. Uses [step 1](../pipeline.md#step-1-split-the-aoi-by-linear-features)
+of the pipeline directly.
+
+SQL: `algorithms/split_by_roads.sql`.
+
+## Idea
+
+Some projects collect street-level data (imagery, road condition
+surveys) rather than per-building data. Mappers walk or cycle roads,
+so task boundaries should follow the street layout, not building
+density. There's no need to cluster buildings or run Voronoi/Straight
+Skeleton at all — the road-bounded polygons that
+`common/1-linear-features.sql` already produces as an intermediate
+step are the final output.
+
+## Steps
+
+1. `common/1-linear-features.sql`: same as for the building-based
+   algorithms — union roads, rivers, railways, aeroways and
+   non-traversable barriers with the AOI boundary, then
+   `ST_Polygonize` to get `polygonsnocount`, one polygon per
+   road-enclosed area. Falls back to the whole AOI as a single polygon
+   if no linear features intersect it.
+
+2. `split_by_roads.sql`: return `polygonsnocount` directly as a
+   GeoJSON `FeatureCollection`, with `building_count` computed against
+   `ways_poly` for informational purposes only (it plays no part in
+   how the polygons are drawn).
+
+## Downsides
+
+- No control over task size — a polygon between two motorway
+  junctions can be much larger or smaller than one between two
+  residential streets.
+- No SFCGAL dependency; runs on any PostGIS install with the standard
+  extensions.
+
+Prefer one of the [Voronoi](voronoi.md) or
+[straight skeleton](straight-skeleton.md) algorithms when the goal is
+even building coverage rather than street coverage.

--- a/src/backend/packages/area-splitter/docs/pipeline.md
+++ b/src/backend/packages/area-splitter/docs/pipeline.md
@@ -108,6 +108,14 @@ features.
 
 Returns the final task polygons as a GeoJSON FeatureCollection.
 
+## Split by roads
+
+`SPLIT_BY_ROADS` only runs step 1, then its own extract query
+(`split_by_roads.sql`) instead of steps 2-6. It returns the
+road-bounded polygons from step 1 (`polygonsnocount`) directly, with
+no building clustering or edge alignment. See
+[docs/algorithms/roads.md](algorithms/roads.md).
+
 ## Non-SQL algorithms
 
 `NO_SPLITTING` and `DIVIDE_BY_SQUARE` do not use the pipeline above.

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -408,6 +408,70 @@ def test_split_by_sql_total_tasks_passes_num_enumerators(
     assert isinstance(features, dict) and features.get("type") == "FeatureCollection"
 
 
+def test_split_by_sql_roads_requires_no_legacy_param(monkeypatch, aoi_json, extract_json):
+    """SPLIT_BY_ROADS has no required_params, so it needs neither num_buildings
+    nor num_enumerators to resolve algorithm params successfully.
+    """
+    captured = {}
+
+    def fake_split_by_sql(
+        self,
+        db,
+        algorithm,
+        algorithm_params,
+        osm_extract,
+        **_kwargs,
+    ):
+        captured["algorithm"] = algorithm
+        captured["algorithm_params"] = algorithm_params
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": aoi_json["features"][0]["geometry"],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(AreaSplitter, "splitBySQL", fake_split_by_sql)
+
+    features = split_by_sql(
+        aoi_json,
+        "postgresql://unused",
+        osm_extract=extract_json,
+        algorithm=SplittingAlgorithm.SPLIT_BY_ROADS,
+    )
+
+    assert captured["algorithm"] == SplittingAlgorithm.SPLIT_BY_ROADS
+    assert captured["algorithm_params"]["include_roads"] == "TRUE"
+    assert isinstance(features, dict) and features.get("type") == "FeatureCollection"
+
+
+def test_split_by_sql_roads_with_extract(aoi_json, extract_json):
+    """Splitting by roads should return polygons bounded by linear features."""
+    features = split_by_sql(
+        aoi_json,
+        DB_URL,
+        osm_extract=extract_json,
+        algorithm=SplittingAlgorithm.SPLIT_BY_ROADS,
+        algorithm_params={
+            "include_roads": "TRUE",
+            "include_rivers": "TRUE",
+            "include_railways": "TRUE",
+            "include_aeroways": "TRUE",
+        },
+    )
+    assert isinstance(features, dict) and features.get("type") == "FeatureCollection"
+    feature_list = features.get("features", [])
+    assert len(feature_list) >= 1
+    assert all(
+        feature.get("geometry", {}).get("type") in {"Polygon", "MultiPolygon"}
+        for feature in feature_list
+    )
+    assert all("building_count" in feature["properties"] for feature in feature_list)
+
+
 def test_split_by_sql_ftm_no_extract(aoi_json):
     """Test Field-TM splitting algorithm, with no data extract."""
     features = split_by_sql(

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -408,7 +408,9 @@ def test_split_by_sql_total_tasks_passes_num_enumerators(
     assert isinstance(features, dict) and features.get("type") == "FeatureCollection"
 
 
-def test_split_by_sql_roads_requires_no_legacy_param(monkeypatch, aoi_json, extract_json):
+def test_split_by_sql_roads_requires_no_legacy_param(
+    monkeypatch, aoi_json, extract_json
+):
     """SPLIT_BY_ROADS has no required_params, so it needs neither num_buildings
     nor num_enumerators to resolve algorithm params successfully.
     """


### PR DESCRIPTION
Closes hotosm/field-tm#3107

## Summary
- Adds a new `SPLIT_BY_ROADS` splitting algorithm for projects collecting street-level data (e.g. imagery), where mappers walk/cycle roads rather than visiting individual buildings.
- Reuses the existing linear-features polygonize step (`common/1-linear-features.sql`, which already unions roads/rivers/railways/aeroways/non-traversable barriers with the AOI boundary and runs `ST_Polygonize`) directly as the final output, skipping the building-clustering/alignment steps (2-5) entirely.
- New `algorithms/split_by_roads.sql` extract query, mirroring `common/6-extract.sql` but sourcing `polygonsnocount` directly, with `building_count` computed against `ways_poly` for informational purposes.
- Refactors `SplittingAlgorithm` to expose a `sql_files` property (ordered SQL pipeline per algorithm) instead of hardcoding the 6-file list inline in `splitter.py`.
- Fixes a latent bug in `_resolve_algorithm_params`: it previously raised "requires the following parameters" even when an algorithm's `required_params` was empty, if no legacy `num_buildings`/`num_enumerators` args were passed. Didn't affect existing algorithms (all have non-empty required params) but is needed for `SPLIT_BY_ROADS` (zero required params) to work correctly.
- Wires the new algorithm into `project_services.py::split_aoi`, the step4 splitting UI dropdown, and the JS param-visibility logic.
- Adds docs following the existing per-algorithm convention: `docs/algorithms/roads.md`, a short new section in `docs/pipeline.md`, a bullet in the package `README.md`, and a new section + table row in the user-facing `docs/manuals/task-splitting.md`.

## Test plan
- [x] `docker compose -f compose.test.yaml run --rm backend pytest package_tests/test_area_splitter` — 46/46 passed, including two new tests for `SPLIT_BY_ROADS` (one exercising the `_resolve_algorithm_params` fix via a monkeypatched call, one running the real SQL pipeline against the `kathmandu_extract.geojson` fixture and asserting valid Polygon/MultiPolygon output).