### PR TITLE
feat(auth): use the shared Hanko login component in the header

### DIFF
--- a/.github/workflows/deploy-testlogin.yml
+++ b/.github/workflows/deploy-testlogin.yml
@@ -1,0 +1,143 @@
+name: Deploy to https://fieldtm.testlogin.hotosm.org
+
+on:
+  push:
+    branches:
+      - login_hanko_v2
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hotosm/field-tm
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          target: prod
+          push: true
+          tags: ghcr.io/${{ env.IMAGE_NAME }}:login_hanko_v2
+          build-args: |
+            MONITORING=yes
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testlogin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.EC2_SSH_KEY }}
+
+      - name: Add host to known_hosts
+        run: ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_USER: ${{ secrets.EC2_USER }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_ACTOR: ${{ github.actor }}
+          COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
+        run: |
+          ssh $EC2_USER@$EC2_HOST << ENDSSH
+            set -e
+
+            # Ensure Traefik is running
+            if ! docker ps | grep -q traefik; then
+              echo "ERROR: Traefik not running. Run setup-test-server.sh first."
+              exit 1
+            fi
+
+            # Ensure hotosm-test network exists
+            docker network inspect hotosm-test >/dev/null 2>&1 || \
+              docker network create hotosm-test
+
+            APP_DIR="/opt/field-tm"
+
+            # Initial setup if directory does not exist
+            if [ ! -d "\$APP_DIR" ]; then
+              sudo mkdir -p \$APP_DIR
+              sudo chown \$USER:\$USER \$APP_DIR
+              git clone -b login_hanko_v2 https://github.com/hotosm/field-tm.git \$APP_DIR
+              echo "Cloned repository"
+            fi
+
+            cd \$APP_DIR
+
+            # Pull latest changes
+            git fetch origin login_hanko_v2
+            git reset --hard origin/login_hanko_v2
+
+            # Create .env with config
+            cat > deploy/.env << EOF
+          FTM_DOMAIN=fieldtm.testlogin.hotosm.org
+          FTM_ODK_DOMAIN=odk.fieldtm.testlogin.hotosm.org
+          GIT_BRANCH=login_hanko_v2
+          FTM_DB_HOST=fieldtm-db
+          FTM_DB_USER=fieldtm
+          FTM_DB_PASSWORD=fieldtm
+          FTM_DB_NAME=fieldtm
+          CENTRAL_DB_HOST=central-db
+          CENTRAL_DB_USER=odk
+          CENTRAL_DB_PASSWORD=odk
+          CENTRAL_DB_NAME=odk
+          COOKIE_SECRET=${COOKIE_SECRET}
+          ENCRYPTION_KEY=pIxxYIXe4oAVHI36lTveyc97FKK2O_l2VHeiuqU-K_4=
+          # custom (not hotosm): hotosm hardcodes login.hotosm.org and would
+          # override the dev.login URLs below, breaking JWT validation.
+          AUTH_PROVIDER=custom
+          HANKO_API_URL=https://dev.login.hotosm.org
+          HANKO_PUBLIC_URL=https://dev.login.hotosm.org
+          LOGIN_URL=https://dev.login.hotosm.org/app
+          JWT_ISSUER=https://dev.login.hotosm.org
+          OSM_CLIENT_ID=placeholder
+          OSM_CLIENT_SECRET=placeholder
+          OSM_SECRET_KEY=placeholder
+          OSM_URL=https://www.openstreetmap.org
+          EOF
+            echo "Created .env"
+
+            # Login to GHCR
+            echo "${GH_TOKEN}" | docker login ghcr.io -u ${GH_ACTOR} --password-stdin
+
+            cd deploy
+
+            # Pull new images
+            docker compose -f compose.testlogin.yaml pull
+
+            # Bring down app containers cleanly (avoids name conflicts on recreate)
+            docker compose -f compose.testlogin.yaml down --remove-orphans || true
+
+            # Ensure db is running
+            docker compose -f compose.testlogin.yaml up -d --no-recreate fieldtm-db central-db
+
+            # Wait for db
+            sleep 5
+
+            # Start fresh app containers
+            docker compose -f compose.testlogin.yaml up -d
+
+            # Cleanup old images
+            docker image prune -af
+
+            echo "Deployment complete: https://fieldtm.testlogin.hotosm.org"
+          ENDSSH

--- a/deploy/compose.testlogin.yaml
+++ b/deploy/compose.testlogin.yaml
@@ -1,0 +1,130 @@
+# Testlogin deployment overlay for Field-TM
+# Uses Traefik (already running on testlogin server) instead of BunkerWeb
+#
+# Usage:
+#   docker compose -f deploy/compose.testlogin.yaml up -d
+
+name: field-tm
+
+networks:
+  ftm-net:
+    name: field-tm
+  hotosm-test:
+    external: true
+
+volumes:
+  ftm_db_data:
+    name: field-tm-db-data
+  ftm_logs:
+    name: field-tm-logs
+  central_db_data:
+    name: field-tm-central-db
+  central_frontend:
+    name: field-tm-central-frontend
+
+services:
+  # API served directly via Traefik (no BunkerWeb)
+  api:
+    image: "ghcr.io/hotosm/field-tm:${GIT_BRANCH:-login_hanko_v2}"
+    volumes:
+      - ftm_logs:/opt/logs
+    depends_on:
+      fieldtm-db:
+        condition: service_healthy
+      migrations:
+        condition: service_completed_successfully
+    env_file:
+      - .env
+    environment:
+      - FTM_DOMAIN=${FTM_DOMAIN}
+      - HANKO_API_URL=${HANKO_API_URL:-https://dev.login.hotosm.org}
+      - HANKO_PUBLIC_URL=${HANKO_PUBLIC_URL:-https://dev.login.hotosm.org}
+      - LOGIN_URL=${LOGIN_URL:-https://dev.login.hotosm.org/app}
+      - JWT_ISSUER=${JWT_ISSUER:-https://dev.login.hotosm.org}
+    networks:
+      - ftm-net
+      - hotosm-test
+    restart: "unless-stopped"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/__lbheartbeat__"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.field-tm-api.rule=Host(`${FTM_DOMAIN}`)"
+      - "traefik.http.routers.field-tm-api.entrypoints=websecure"
+      - "traefik.http.routers.field-tm-api.tls=true"
+      - "traefik.http.routers.field-tm-api.tls.certresolver=letsencrypt"
+      - "traefik.http.services.field-tm-api.loadbalancer.server.port=8000"
+      - "traefik.docker.network=hotosm-test"
+
+  migrations:
+    image: "ghcr.io/hotosm/field-tm:${GIT_BRANCH:-login_hanko_v2}"
+    depends_on:
+      fieldtm-db:
+        condition: service_healthy
+    env_file:
+      - .env
+    networks:
+      - ftm-net
+    entrypoint: ["/migrate-entrypoint.sh"]
+    restart: "on-failure:2"
+
+  fieldtm-db:
+    image: "ghcr.io/hotosm/postgis:18-3.6-alpine"
+    command: -c 'max_connections=64'
+    volumes:
+      - ftm_db_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=${FTM_DB_USER:-fieldtm}
+      - POSTGRES_PASSWORD=${FTM_DB_PASSWORD:-fieldtm}
+      - POSTGRES_DB=${FTM_DB_NAME:-fieldtm}
+    networks:
+      - ftm-net
+    restart: "unless-stopped"
+    healthcheck:
+      test: pg_isready -U ${FTM_DB_USER:-fieldtm} -d ${FTM_DB_NAME:-fieldtm}
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # ODK Central services (optional, for full Field-TM functionality)
+  central:
+    image: "ghcr.io/hotosm/field-tm/odkcentral:v2025.4.4"
+    depends_on:
+      central-db:
+        condition: service_healthy
+    environment:
+      - DOMAIN=${FTM_ODK_DOMAIN:-odk.${FTM_DOMAIN}}
+      - HTTPS_PORT=443
+      - SYSADMIN_EMAIL=${CENTRAL_ADMIN_EMAIL:-admin@hotosm.org}
+      - DB_HOST=central-db
+      - DB_USER=${CENTRAL_DB_USER:-odk}
+      - DB_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - DB_NAME=${CENTRAL_DB_NAME:-odk}
+      - DB_SSL=null
+    networks:
+      - ftm-net
+    restart: "unless-stopped"
+
+  central-db:
+    image: "ghcr.io/hotosm/postgis:14-3.5-alpine"
+    environment:
+      - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
+      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
+    volumes:
+      - central_db_data:/var/lib/postgresql/data
+    networks:
+      - ftm-net
+    restart: "unless-stopped"
+    command: -c 'max_connections=64'
+    healthcheck:
+      test: pg_isready -U ${CENTRAL_DB_USER:-odk} -d ${CENTRAL_DB_NAME:-odk}
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3

--- a/src/backend/app/static/css/app.css
+++ b/src/backend/app/static/css/app.css
@@ -31,6 +31,20 @@ body {
   --ftm-radius-sm: var(--hot-border-radius-medium, 0.25rem);
 }
 
+/* --- Auth: login button (hotosm-auth web component) ------- */
+/* Theme the logged-out login button to match the previous brand
+   button. Custom properties pierce the component's shadow DOM.
+   Only affects the login button; the profile dropdown keeps its
+   own defaults. */
+hotosm-auth {
+  --login-btn-bg-color: var(--ftm-brand);
+  --login-btn-hover-bg-color: var(--hot-color-primary-700, #b93636);
+  --login-btn-text-color: var(--hot-color-neutral-0, #ffffff);
+  --login-btn-border-radius: var(--ftm-radius-sm);
+  --login-btn-padding: var(--hot-spacing-small, 0.5rem)
+    var(--hot-spacing-medium, 1rem);
+}
+
 /* --- Page layouts ----------------------------------------- */
 .ftm-page {
   padding: 24px;

--- a/src/backend/app/static/css/app.css
+++ b/src/backend/app/static/css/app.css
@@ -34,15 +34,17 @@ body {
 /* --- Auth: login button (hotosm-auth web component) ------- */
 /* Theme the logged-out login button to match the previous brand
    button. Custom properties pierce the component's shadow DOM.
-   Only affects the login button; the profile dropdown keeps its
-   own defaults. */
+   Uses the HOT brand red as a literal value: nesting var(--ftm-brand)
+   -> var(--hot-color-primary-600) resolves inconsistently once inherited
+   into the component's shadow DOM (it fell back to gray-600), so we set
+   the colour directly. Only affects the login button; the profile
+   dropdown keeps its own defaults. */
 hotosm-auth {
-  --login-btn-bg-color: var(--ftm-brand);
-  --login-btn-hover-bg-color: var(--hot-color-primary-700, #b93636);
-  --login-btn-text-color: var(--hot-color-neutral-0, #ffffff);
-  --login-btn-border-radius: var(--ftm-radius-sm);
-  --login-btn-padding: var(--hot-spacing-small, 0.5rem)
-    var(--hot-spacing-medium, 1rem);
+  --login-btn-bg-color: #d73f3f;
+  --login-btn-hover-bg-color: #b93636;
+  --login-btn-text-color: #ffffff;
+  --login-btn-border-radius: 0.25rem;
+  --login-btn-padding: 0.5rem 1rem;
 }
 
 /* --- Page layouts ----------------------------------------- */

--- a/src/backend/app/templates/layout.html
+++ b/src/backend/app/templates/layout.html
@@ -194,7 +194,15 @@
         </div>
       </wa-dropdown>
       {% if auth_enabled %}
-      <wa-button slot="auth" variant="brand" id="login-btn">{{ _("Login") }}</wa-button>
+      <!-- Shared Hanko web component: renders the login button when logged out
+           (redirects to the central login page) and the user profile dropdown
+           with logout when logged in. Same pattern as the other HOT apps. -->
+      <hotosm-auth
+        slot="auth"
+        hanko-url="{{ hanko_public_url }}"
+        login-url="{{ login_url }}"
+        lang="{{ current_locale() }}"
+      ></hotosm-auth>
       {% endif %}
     </hot-header>
 
@@ -204,13 +212,7 @@
       domain="field.hotosm.org"
     ></hot-tracking>
 
-    {% if auth_enabled %}
-    <!-- Hidden session verifier: validates the Hanko session after redirect back
-         from the login page and emits hanko-login. -->
-    <div style="display: none">
-      <hotosm-auth hanko-url="{{ hanko_public_url }}"></hotosm-auth>
-    </div>
-    {% endif %} {% block content %}{% endblock %}
+    {% block content %}{% endblock %}
 
     <script>
       // Strip ?lang= from the URL after the locale cookie middleware has set
@@ -232,15 +234,6 @@
       });
 
       {% if auth_enabled %}
-      const loginButton = document.getElementById("login-btn");
-      if (loginButton) {
-        loginButton.addEventListener("click", () => {
-          const returnTo = encodeURIComponent(window.location.href);
-          const separator = "{{ login_url }}".includes("?") ? "&" : "?";
-          window.location.href = `{{ login_url }}${separator}return_to=${returnTo}`;
-        });
-      }
-
       // Sync the authenticated user into the Field-TM database once per browser
       // session. hotosm-auth validates the session and emits 'hanko-login' on
       // every page load when a session is found; sessionStorage prevents us

--- a/src/backend/app/templates/layout.html
+++ b/src/backend/app/templates/layout.html
@@ -202,6 +202,8 @@
         hanko-url="{{ hanko_public_url }}"
         login-url="{{ login_url }}"
         lang="{{ current_locale() }}"
+        button-variant="filled"
+        button-color="danger"
       ></hotosm-auth>
       {% endif %}
     </hot-header>

--- a/src/backend/app/templates/layout.html
+++ b/src/backend/app/templates/layout.html
@@ -258,33 +258,39 @@
           }
 
           // 2. Adopt the language from the HOT login profile (issue #3038).
-          // One-way sync: login -> Field-TM. Applied once per session via
-          // ?lang=, which the locale middleware persists into ftm_locale. The
-          // guard is set up-front so the reload can never loop, and so a manual
-          // switcher choice later in the session is respected.
-          if (!sessionStorage.getItem("ftm_locale_synced")) {
-            sessionStorage.setItem("ftm_locale_synced", "1");
-            try {
-              const profileResp = await fetch("{{ hanko_public_url }}/api/profile/me", { credentials: "include" });
-              if (profileResp.ok) {
-                const profile = await profileResp.json();
-                const lang = (profile.language || "").toLowerCase();
-                if (lang && lang !== ftmLocale) {
+          // One-way: login -> Field-TM. We remember the last profile language
+          // we saw (localStorage) and only re-apply when it *changes*. This way
+          // a profile language change is reflected on the next reload, while a
+          // manual switcher choice is respected as long as the profile language
+          // stays the same. Applied via ?lang=, which the locale middleware
+          // persists into the ftm_locale cookie.
+          try {
+            const profileResp = await fetch("{{ hanko_public_url }}/api/profile/me", { credentials: "include" });
+            if (profileResp.ok) {
+              const profile = await profileResp.json();
+              const lang = (profile.language || "").toLowerCase();
+              const lastSeen = localStorage.getItem("ftm_profile_lang");
+              if (lang && lang !== lastSeen) {
+                // Profile language changed (or first login): remember it up
+                // front so the reload below can never loop, then apply it.
+                localStorage.setItem("ftm_profile_lang", lang);
+                if (lang !== ftmLocale) {
                   const url = new URL(window.location.href);
                   url.searchParams.set("lang", lang);
                   window.location.assign(url.toString());
                 }
               }
-            } catch (e) {
-              console.warn("Field-TM: failed to read login language:", e);
             }
+          } catch (e) {
+            console.warn("Field-TM: failed to read login language:", e);
           }
         });
 
-        // Clear the flags on logout so the next login re-syncs profile + locale.
+        // Clear the flags on logout so the next login re-syncs profile + locale
+        // (a different user may have a different language).
         hotosmAuth.addEventListener("hanko-logout", () => {
           sessionStorage.removeItem("ftm_profile_synced");
-          sessionStorage.removeItem("ftm_locale_synced");
+          localStorage.removeItem("ftm_profile_lang");
         });
       }
       {% endif %}

--- a/src/backend/app/templates/layout.html
+++ b/src/backend/app/templates/layout.html
@@ -236,27 +236,55 @@
       });
 
       {% if auth_enabled %}
-      // Sync the authenticated user into the Field-TM database once per browser
-      // session. hotosm-auth validates the session and emits 'hanko-login' on
-      // every page load when a session is found; sessionStorage prevents us
-      // hitting the endpoint on each navigation after the first sync.
+      // hotosm-auth emits 'hanko-login' on every page load when a session is
+      // found. We run two one-per-session tasks (guarded via sessionStorage so
+      // navigation doesn't re-trigger them):
+      //   1. Register/sync the authenticated user in the Field-TM database.
+      //   2. Adopt the user's language preference from their HOT login profile.
       const hotosmAuth = document.querySelector("hotosm-auth");
+      const ftmLocale = "{{ current_locale() }}";
       if (hotosmAuth) {
         hotosmAuth.addEventListener("hanko-login", async () => {
-          if (sessionStorage.getItem("ftm_profile_synced")) return;
-          try {
-            const resp = await fetch("/api/v1/auth/profile/me", { credentials: "include" });
-            if (resp.ok) {
-              sessionStorage.setItem("ftm_profile_synced", "1");
+          // 1. Sync the user into the Field-TM database.
+          if (!sessionStorage.getItem("ftm_profile_synced")) {
+            try {
+              const resp = await fetch("/api/v1/auth/profile/me", { credentials: "include" });
+              if (resp.ok) {
+                sessionStorage.setItem("ftm_profile_synced", "1");
+              }
+            } catch (e) {
+              console.warn("Field-TM: failed to sync user profile:", e);
             }
-          } catch (e) {
-            console.warn("Field-TM: failed to sync user profile:", e);
+          }
+
+          // 2. Adopt the language from the HOT login profile (issue #3038).
+          // One-way sync: login -> Field-TM. Applied once per session via
+          // ?lang=, which the locale middleware persists into ftm_locale. The
+          // guard is set up-front so the reload can never loop, and so a manual
+          // switcher choice later in the session is respected.
+          if (!sessionStorage.getItem("ftm_locale_synced")) {
+            sessionStorage.setItem("ftm_locale_synced", "1");
+            try {
+              const profileResp = await fetch("{{ hanko_public_url }}/api/profile/me", { credentials: "include" });
+              if (profileResp.ok) {
+                const profile = await profileResp.json();
+                const lang = (profile.language || "").toLowerCase();
+                if (lang && lang !== ftmLocale) {
+                  const url = new URL(window.location.href);
+                  url.searchParams.set("lang", lang);
+                  window.location.assign(url.toString());
+                }
+              }
+            } catch (e) {
+              console.warn("Field-TM: failed to read login language:", e);
+            }
           }
         });
 
-        // Clear the flag on logout so the next login triggers a fresh sync.
+        // Clear the flags on logout so the next login re-syncs profile + locale.
         hotosmAuth.addEventListener("hanko-logout", () => {
           sessionStorage.removeItem("ftm_profile_synced");
+          sessionStorage.removeItem("ftm_locale_synced");
         });
       }
       {% endif %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #3038

## Describe this PR

Wires Field-TM into the shared HOT login (Hanko SSO), the same way the other
HOT apps do it.

Until now the header had its own `<wa-button id="login-btn">` that redirected to
the login page by hand, and the `<hotosm-auth>` web component was hidden away in
a `display: none` div purely to validate the session after the redirect back.
This PR drops the custom button and puts `<hotosm-auth>` in the header slot
directly, so the shared component renders both states: the login button when
logged out, and the user profile dropdown with logout when logged in.

Two things run off the component's `hanko-login` event, both guarded so
navigation doesn't re-trigger them:

1. **User sync** — registers/syncs the authenticated user into the Field-TM
   database via `/api/v1/auth/profile/me`, once per browser session
   (`sessionStorage`). Same behaviour as before, just moved.
2. **Language adoption (#3038)** — reads the user's language from their HOT
   login profile and applies it via `?lang=`, which the existing locale
   middleware persists into the `ftm_locale` cookie. This is one-way
   (login → Field-TM) and only fires when the profile language *changes*: we
   remember the last value we saw in `localStorage`, so a profile change shows
   up on the next load, while a manual choice in the language switcher is
   respected as long as the profile language stays put.

On logout both flags are cleared, so a different user logging in on the same
browser gets a fresh sync and their own language.

Also included: a `deploy-testlogin.yml` workflow and `compose.testlogin.yaml`
that stand up the test environment described below, pointing at
`dev.login.hotosm.org`.

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Claude Code (Claude Opus 5)

## Screenshots

N/A — the header login button and profile dropdown are the shared component's
own UI, unchanged apart from the brand colour noted below.

## Alternative Approaches Considered

**Theming the login button.** The obvious way to colour it was
`--login-btn-bg-color: var(--ftm-brand)`, but `--ftm-brand` is itself
`var(--hot-color-primary-600)`, and that nested indirection resolves
inconsistently once inherited into the component's shadow DOM — it fell back to
gray-600. So the CSS sets the HOT red as a literal `#d73f3f`. Only the login
button is affected; the profile dropdown keeps the component's defaults.

**Syncing language both ways.** Deliberately not done. Pushing a Field-TM
switcher choice back up to the login profile would make the central profile
mutable from every app, and two apps disagreeing would fight over it. One-way
adoption with change-detection gives the useful behaviour (your profile language
follows you into Field-TM) without that.

## Review Guide

**A live test environment is deployed from this branch:**
👉 **https://fieldtm.testlogin.hotosm.org**

It runs against `dev.login.hotosm.org` for auth, so you can log in with a dev
Hanko account and exercise the whole flow without touching production. It
redeploys automatically on every push to this branch.

Worth checking there:

- Logged out → the header shows the red **Login** button; clicking it takes you
  to the central login page and returns you to where you were.
- Logged in → the button is replaced by the profile dropdown, and logout works
  from it.
- First login → the user appears in the Field-TM database (the profile sync).
- Set a language on your HOT login profile, then reload Field-TM → the UI
  switches to it.
- Then change the language with Field-TM's own switcher and navigate around →
  your manual choice sticks, it doesn't get overwritten on every page load.
- Log out and back in as a different user with a different profile language →
  you get theirs, not the previous user's.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [x] PR is focused and small
- [ ] Tests are included or updated
- [x] I understand all code in this PR and can answer questions about it
- [x] No secrets, credentials, or sensitive data are included
- [x] Commit messages are descriptive
- [ ] Related docs and screenshots are updated
